### PR TITLE
fix: porting upsteam repo fix for casting error

### DIFF
--- a/labs/advanced-load-balancing/policy.xml
+++ b/labs/advanced-load-balancing/policy.xml
@@ -46,7 +46,7 @@
         </set-header>
     </inbound>
     <backend>
-        <retry condition="@(context.Response != null && (context.Response.StatusCode == 429 || context.Response.StatusCode >= 500) && ((Int32)context.Variables["remainingBackends"]) > 0)" count="50" interval="0">
+        <retry condition="@(context.Response != null && (context.Response.StatusCode == 429 || context.Response.StatusCode >= 500) && (int.Parse((string)context.Variables["remainingBackends"])) > 0)" count="50" interval="0">
             <!-- Before picking the backend, let's verify if there is any that should be set to not throttling anymore -->
             <set-variable name="listBackends" value="@{
                 JArray backends = (JArray)context.Variables["listBackends"];


### PR DESCRIPTION
## Purpose
Ports upstream fix in https://github.com/Azure-Samples/openai-apim-lb/pull/26

Issue was a casting error causing 500s on every Azure OpenAI call.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

We manually verified the changes.
