### PR TITLE
Lab 'advanced-load-balancing' -- Fix Retry-Policy glitch (#54)

### DIFF
--- a/labs/advanced-load-balancing/policy.xml
+++ b/labs/advanced-load-balancing/policy.xml
@@ -46,7 +46,7 @@
         </set-header>
     </inbound>
     <backend>
-        <retry condition="@(context.Response != null && (context.Response.StatusCode == 429 || context.Response.StatusCode >= 500) && (int.Parse((string)context.Variables["remainingBackends"])) > 0)" count="50" interval="0">
+        <retry condition="@(context.Response != null && (context.Response.StatusCode == 429 || context.Response.StatusCode >= 500) && (Convert.ToInt32(context.Variables["remainingBackends"]) > 0))" count="50" interval="0">
             <!-- Before picking the backend, let's verify if there is any that should be set to not throttling anymore -->
             <set-variable name="listBackends" value="@{
                 JArray backends = (JArray)context.Variables["listBackends"];


### PR DESCRIPTION
## Purpose

Fix issue #54.

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->
```text
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```text
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Run 'advanced-load-balancing' lab (reduce AOAI capacity to 2).
* Copy execution loop from 'backend-pool-load-balancing' lab.
* See that retry works for run 3.
