### PR TITLE
feat: create OAuth endpoints automatically in MCP Client Authorization lab

### DIFF
--- a/labs/mcp-client-authorization/src/apim-oauth/authorize.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/authorize.policy.xml
@@ -1,0 +1,99 @@
+<!--
+    AUTHORIZE POLICY
+    This policy implements the authorization endpoint for PKCE OAuth2 flow with Entra ID.
+    
+    Flow:
+    1. MCP client calls this endpoint with code_challenge and code_challenge_method
+    2. We generate a code verifier and challenge for Entra ID
+    3. We generate a confirmation code to return to the MCP client later
+    4. We redirect the user to Entra ID login page
+    5. After authentication, Entra ID will redirect back to the callback endpoint
+-->
+<policies>
+    <inbound>
+        <base />
+        <!-- STEP 1: Retrieve PKCE parameters from MCP Client request -->
+        <set-variable name="mcpClientCodeChallenge" value="@((string)context.Request.Url.Query.GetValueOrDefault("code_challenge", ""))" />
+        <set-variable name="mcpClientCodeChallengeMethod" value="@((string)context.Request.Url.Query.GetValueOrDefault("code_challenge_method", ""))" />
+        <!-- STEP 2: Generate PKCE parameters for Entra ID authentication -->
+        <!-- Generate a random code verifier for Entra ID -->
+        <set-variable name="codeVerifier" value="@((string)Guid.NewGuid().ToString().Replace("-", ""))" />
+        <!-- Set the code challenge method for Entra ID -->
+        <set-variable name="codeChallengeMethod" value="S256" />
+        <!-- Generate a code challenge using SHA-256 for Entra ID -->
+        <set-variable name="codeChallenge" value="@{
+            using (var sha256 = System.Security.Cryptography.SHA256.Create())
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes((string)context.Variables.GetValueOrDefault("codeVerifier", ""));
+                var hash = sha256.ComputeHash(bytes);
+                return System.Convert.ToBase64String(hash).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            }
+            }" />
+        <!-- STEP 3: Extract client information and create state parameter -->
+        <set-variable name="clientId" value="@((string)context.Request.Url.Query.GetValueOrDefault("client_id", ""))" />
+        <set-variable name="state" value="@((string)Guid.NewGuid().ToString())" />
+        <!-- STEP 4: Construct the Entra ID authorization URL -->
+        <!-- Base URL for Entra ID authorization endpoint -->
+        <set-variable name="baseAuthUrl" value="https://login.microsoftonline.com/{{EntraIDTenantId}}/oauth2/v2.0/authorize?response_type=code" />
+        <!-- Add client ID parameter -->
+        <set-variable name="clientIdParam" value="@(string.Concat("&client_id=", context.Variables.GetValueOrDefault("clientId", "")))" />        
+        <!-- Add PKCE parameters -->
+        <set-variable name="codeChallengeParam" value="@(string.Concat("&code_challenge=", context.Variables.GetValueOrDefault("codeChallenge", "")))" />
+        <set-variable name="codeChallengeMethodParam" value="@(string.Concat("&code_challenge_method=", context.Variables.GetValueOrDefault("codeChallengeMethod", "")))" />
+        <!-- Add OAuth callback parameter -->
+        <set-variable name="redirectUriParam" value="@(string.Concat("&redirect_uri=", "{{OAuthCallbackUri}}" ))" />        
+        <!-- Add required scope parameter -->
+        <set-variable name="scopeParam" value="@(string.Concat("&scope={{OAuthScopes}}"))" />
+        <!-- Add state parameter for security -->
+        <set-variable name="stateParam" value="@(string.Concat("&state=", context.Variables.GetValueOrDefault("state", "")))" />
+          <!-- Combine all parts to form the complete authorization URL with PKCE params -->
+        <set-variable name="authUrl" value="@(string.Concat(
+            context.Variables.GetValueOrDefault("baseAuthUrl", ""), 
+            context.Variables.GetValueOrDefault("clientIdParam", ""), 
+            context.Variables.GetValueOrDefault("codeChallengeParam", ""), 
+            context.Variables.GetValueOrDefault("codeChallengeMethodParam", ""), 
+            context.Variables.GetValueOrDefault("redirectUriParam", ""), 
+            context.Variables.GetValueOrDefault("scopeParam", ""), 
+            context.Variables.GetValueOrDefault("stateParam", "")))" />        
+        <!-- STEP 5: Store authentication data in cache for use in callback -->
+        <!-- Generate a confirmation code to return to the MCP client -->
+        <set-variable name="mcpConfirmConsentCode" value="@((string)Guid.NewGuid().ToString())" />
+        
+        <!-- Store code verifier for token exchange -->
+        <cache-store-value duration="700" 
+            key="CodeVerifier-@(context.Variables.GetValueOrDefault("state", ""))" 
+            value="@(context.Variables.GetValueOrDefault("codeVerifier", ""))" />
+        
+        <!-- Map state to MCP confirmation code for callback -->
+        <cache-store-value duration="700" 
+            key="@((string)context.Variables.GetValueOrDefault("state"))" 
+            value="@(context.Variables.GetValueOrDefault("mcpConfirmConsentCode", ""))" />
+        
+        <!-- Store MCP client PKCE data for verification during token exchange -->
+        <cache-store-value duration="700" 
+            key="@($"McpClientAuthData-{context.Variables.GetValueOrDefault("mcpConfirmConsentCode")}")" 
+            value="@{
+                // Create a JObject and populate it with values
+                return new JObject{
+                    ["mcpClientCodeChallenge"] = (string)context.Variables.GetValueOrDefault("mcpClientCodeChallenge", ""),
+                    ["mcpClientCodeChallengeMethod"] = (string)context.Variables.GetValueOrDefault("mcpClientCodeChallengeMethod", "")
+                }.ToString();
+            }" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />        
+        <!-- Return the response with a 302 status code for redirect -->
+        <return-response>
+            <set-status code="302" reason="Found" />
+            <set-header name="Location" exists-action="override">
+                <value>@(context.Variables.GetValueOrDefault("authUrl", ""))</value>
+            </set-header>
+        </return-response>
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/labs/mcp-client-authorization/src/apim-oauth/oauth-callback.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/oauth-callback.policy.xml
@@ -1,0 +1,96 @@
+<!--
+    OAUTH CALLBACK POLICY
+    This policy implements the callback endpoint for PKCE OAuth2 flow with Entra ID.
+    
+    Flow:
+    1. Entra ID redirects to this endpoint with authorization code after user login
+    2. We exchange the authorization code for an access token
+    3. We retrieve the stored MCP client data and generate a session key
+    4. We redirect back to the MCP client with a confirmation code
+-->
+<policies>
+    <inbound>
+        <base />
+        <!-- STEP 1: Extract the authorization code and state from Entra ID callback -->
+        <set-variable name="authCode" value="@((string)context.Request.Url.Query.GetValueOrDefault("code", ""))" />
+        <set-variable name="entraState" value="@((string)context.Request.Url.Query.GetValueOrDefault("state", ""))" />
+        <set-variable name="sessionState" value="@((string)context.Request.Url.Query.GetValueOrDefault("session_state", ""))" />
+        
+        <!-- STEP 2: Retrieve stored PKCE code verifier using the state parameter -->
+        <cache-lookup-value key="CodeVerifier-@(context.Variables.GetValueOrDefault("entraState", ""))" variable-name="codeVerifier" />
+        <!-- STEP 3: Set token request parameters -->
+        <set-variable name="codeChallengeMethod" value="S256" />
+        <set-variable name="redirectUri" value="{{OAuthCallbackUri}}" />
+        <set-variable name="clientId" value="{{EntraIDClientId}}" />
+        <set-variable name="clientSecret" value="{{EntraIDClientSecret}}" />
+        
+        <!-- STEP 4: Configure token request to Entra ID -->
+        <set-method>POST</set-method>
+        <set-header name="Content-Type" exists-action="override">
+            <value>application/x-www-form-urlencoded</value>
+        </set-header>
+        <set-body>@{
+            return $"client_id={context.Variables.GetValueOrDefault("clientId")}&grant_type=authorization_code&code={context.Variables.GetValueOrDefault("authCode")}&redirect_uri={context.Variables.GetValueOrDefault("redirectUri")}&scope=https://graph.microsoft.com/.default";
+        }</set-body>
+        <rewrite-uri template="/token" />
+    </inbound>
+
+    <backend>
+        <base />
+    </backend>
+
+    <outbound>
+        <base />
+        <!-- STEP 5: Process the token response from Entra ID -->
+        <trace source="apim-policy">
+            <message>@("Token response received: " + context.Response.Body.As<string>(preserveContent: true))</message>
+        </trace>        
+        <!-- STEP 6: Lookup MCP client redirect URI stored during authorization -->
+        <cache-lookup-value key="@($"McpClientAuthData-{context.Variables.GetValueOrDefault("mcpConfirmConsentCode")}")" variable-name="mcpClientData" />
+          <!-- Retrieve the client's redirect URI from cache -->
+        <cache-lookup-value key="ClientRedirectUri" variable-name="callbackRedirectUri" />
+          <!-- STEP 7: Generate secure session token for MCP client -->
+        <set-variable name="IV" value="{{EncryptionIV}}" />
+        <set-variable name="key" value="{{EncryptionKey}}" />
+        <set-variable name="encryptedSessionKey" value="@{
+            // Generate a unique session ID
+            string sessionId = "sessionId123";
+            byte[] sessionIdBytes = Encoding.UTF8.GetBytes(sessionId);
+            
+            // Encrypt the session ID using AES
+            byte[] IV = Convert.FromBase64String((string)context.Variables["IV"]);
+            byte[] key = Convert.FromBase64String((string)context.Variables["key"]);
+            
+            byte[] encryptedBytes = sessionIdBytes.Encrypt("Aes", key, IV);
+            
+            return Convert.ToBase64String(encryptedBytes);
+        }" />
+
+        <!-- STEP 8: Generate new state for MCP client -->
+        <set-variable name="mcpState" value="@((string)Guid.NewGuid().ToString())" />
+        <cache-lookup-value key="@((string)context.Variables.GetValueOrDefault("entraState"))" variable-name="mcpConfirmConsentCode" />
+        
+        <!-- STEP 9: Store the encrypted session key and Entra token in cache -->
+        <!-- Store the encrypted session key with the MCP confirmation code as key -->
+        <cache-store-value duration="700" 
+            key="@($"AccessToken-{context.Variables.GetValueOrDefault("mcpConfirmConsentCode")}")" 
+            value="@($"{context.Variables.GetValueOrDefault("encryptedSessionKey")}")" />
+        
+        <!-- Store the Entra token for later use -->
+        <cache-store-value duration="700" 
+            key="@($"EntraToken-{context.Variables.GetValueOrDefault("mcpConfirmConsentCode")}")" 
+            value="@(context.Response.Body.As<JObject>(preserveContent: true).ToString())" />
+        
+        <!-- STEP 10: Redirect back to MCP client with confirmation code -->
+        <return-response>
+            <set-status code="302" reason="Found" />
+            <set-header name="Location" exists-action="override">
+                <value>@($"{context.Variables.GetValueOrDefault("callbackRedirectUri")}?code={context.Variables.GetValueOrDefault("mcpConfirmConsentCode")}&state={context.Variables.GetValueOrDefault("mcpState")}&state_session=statesession123")</value>
+            </set-header>
+            <set-body />
+        </return-response>
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/labs/mcp-client-authorization/src/apim-oauth/oauth.bicep
+++ b/labs/mcp-client-authorization/src/apim-oauth/oauth.bicep
@@ -1,0 +1,294 @@
+@description('The name of the API Management service')
+param apimServiceName string
+
+// Parameters for Named Values
+@description('The Entra ID tenant ID')
+param entraIDTenantId string
+
+@description('The client ID for Entra ID app registration')
+param entraIDClientId string
+
+@description('The client secret for Entra ID app registration')
+@secure()
+param entraIDClientSecret string
+
+@description('The required scopes for authorization')
+param oauthScopes string
+
+@description('The encryption IV for session token')
+@secure()
+param encryptionIV string
+
+@description('The encryption key for session token')
+@secure()
+param encryptionKey string
+
+@description('The MCP client ID')
+param mcpClientId string
+
+resource apimService 'Microsoft.ApiManagement/service@2021-08-01' existing = {
+  name: apimServiceName
+}
+
+// Define the Named Values
+resource EntraIDTenantIdNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-08-01' = {
+  parent: apimService
+  name: 'EntraIDTenantId'
+  properties: {
+    displayName: 'EntraIDTenantId'
+    value: entraIDTenantId
+    secret: false
+  }
+}
+
+resource EntraIDClientIdNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-08-01' = {
+  parent: apimService
+  name: 'EntraIDClientId'
+  properties: {
+    displayName: 'EntraIDClientId'
+    value: entraIDClientId
+    secret: false
+  }
+}
+
+resource EntraIDClientSecretNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-08-01' = {
+  parent: apimService
+  name: 'EntraIDClientSecret'
+  properties: {
+    displayName: 'EntraIDClientSecret'
+    value: entraIDClientSecret
+    secret: true
+  }
+}
+
+resource OAuthCallbackUriNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-08-01' = {
+  parent: apimService
+  name: 'OAuthCallbackUri'
+  properties: {
+    displayName: 'OAuthCallbackUri'
+    value: '${apimService.properties.gatewayUrl}/oauth-callback'
+    secret: false
+  }
+}
+
+resource OAuthScopesNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-08-01' = {
+  parent: apimService
+  name: 'OAuthScopes'
+  properties: {
+    displayName: 'OAuthScopes'
+    value: oauthScopes
+    secret: false
+  }
+}
+
+resource EncryptionIVNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-08-01' = {
+  parent: apimService
+  name: 'EncryptionIV'
+  properties: {
+    displayName: 'EncryptionIV'
+    value: encryptionIV
+    secret: true
+  }
+}
+
+resource EncryptionKeyNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-08-01' = {
+  parent: apimService
+  name: 'EncryptionKey'
+  properties: {
+    displayName: 'EncryptionKey'
+    value: encryptionKey
+    secret: true
+  }
+}
+
+resource McpClientIdNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-08-01' = {
+  parent: apimService
+  name: 'McpClientId'
+  properties: {
+    displayName: 'McpClientId'
+    value: mcpClientId
+    secret: false
+  }
+}
+
+resource APIMGatewayURLNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-08-01' = {
+  parent: apimService
+  name: 'APIMGatewayURL'
+  properties: {
+    displayName: 'APIMGatewayURL'
+    value: apimService.properties.gatewayUrl
+    secret: false
+  }
+}
+
+// Create the OAuth API
+resource oauthApi 'Microsoft.ApiManagement/service/apis@2021-08-01' = {
+  parent: apimService
+  name: 'oauth'
+  properties: {
+    displayName: 'OAuth'
+    description: 'OAuth 2.0 Authentication API'
+    subscriptionRequired: false
+    path: ''
+    protocols: [
+      'https'
+    ]
+    serviceUrl: 'https://login.microsoftonline.com/${entraIDTenantId}/oauth2/v2.0'
+  }
+}
+
+// Add a GET operation for the authorization endpoint
+resource oauthAuthorizeOperation 'Microsoft.ApiManagement/service/apis/operations@2021-08-01' = {
+  parent: oauthApi
+  name: 'authorize'
+  properties: {
+    displayName: 'Authorize'
+    method: 'GET'
+    urlTemplate: '/authorize'
+    description: 'OAuth 2.0 authorization endpoint'
+  }
+}
+
+// Add policy for the authorize operation
+resource oauthAuthorizePolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2021-08-01' = {
+  parent: oauthAuthorizeOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: loadTextContent('authorize.policy.xml')
+  }
+}
+
+// Add a POST operation for the token endpoint
+resource oauthTokenOperation 'Microsoft.ApiManagement/service/apis/operations@2021-08-01' = {
+  parent: oauthApi
+  name: 'token'
+  properties: {
+    displayName: 'Token'
+    method: 'POST'
+    urlTemplate: '/token'
+    description: 'OAuth 2.0 token endpoint'
+  }
+}
+
+// Add policy for the token operation
+resource oauthTokenPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2021-08-01' = {
+  parent: oauthTokenOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: loadTextContent('token.policy.xml')
+  }
+}
+
+// Add a GET operation for the OAuth callback endpoint
+resource oauthCallbackOperation 'Microsoft.ApiManagement/service/apis/operations@2021-08-01' = {
+  parent: oauthApi
+  name: 'oauth-callback'
+  properties: {
+    displayName: 'OAuth Callback'
+    method: 'GET'
+    urlTemplate: '/oauth-callback'
+    description: 'OAuth 2.0 callback endpoint to handle authorization code flow'
+  }
+}
+
+// Add policy for the OAuth callback operation
+resource oauthCallbackPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2021-08-01' = {
+  parent: oauthCallbackOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: loadTextContent('oauth-callback.policy.xml')
+  }
+}
+
+// Add a POST operation for the register endpoint
+resource oauthRegisterOperation 'Microsoft.ApiManagement/service/apis/operations@2021-08-01' = {
+  parent: oauthApi
+  name: 'register'
+  properties: {
+    displayName: 'Register'
+    method: 'POST'
+    urlTemplate: '/register'
+    description: 'OAuth 2.0 client registration endpoint'
+  }
+}
+
+// Add policy for the register operation
+resource oauthRegisterPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2021-08-01' = {
+  parent: oauthRegisterOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: loadTextContent('register.policy.xml')
+  }
+}
+
+// Add a OPTIONS operation for the register endpoint
+resource oauthRegisterOptionsOperation 'Microsoft.ApiManagement/service/apis/operations@2021-08-01' = {
+  parent: oauthApi
+  name: 'register-options'
+  properties: {
+    displayName: 'Register Options'
+    method: 'OPTIONS'
+    urlTemplate: '/register'
+    description: 'CORS preflight request handler for register endpoint'
+  }
+}
+
+// Add policy for the register options operation
+resource oauthRegisterOptionsPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2021-08-01' = {
+  parent: oauthRegisterOptionsOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: loadTextContent('register-options.policy.xml')
+  }
+}
+
+// Add a OPTIONS operation for the OAuth metadata endpoint
+resource oauthMetadataOptionsOperation 'Microsoft.ApiManagement/service/apis/operations@2021-08-01' = {
+  parent: oauthApi
+  name: 'oauthmetadata-options'
+  properties: {
+    displayName: 'OAuth Metadata Options'
+    method: 'OPTIONS'
+    urlTemplate: '/.well-known/oauth-authorization-server'
+    description: 'CORS preflight request handler for OAuth metadata endpoint'
+  }
+}
+
+// Add policy for the OAuth metadata options operation
+resource oauthMetadataOptionsPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2021-08-01' = {
+  parent: oauthMetadataOptionsOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: loadTextContent('oauthmetadata-options.policy.xml')
+  }
+}
+
+// Add a GET operation for the OAuth metadata endpoint
+resource oauthMetadataGetOperation 'Microsoft.ApiManagement/service/apis/operations@2021-08-01' = {
+  parent: oauthApi
+  name: 'oauthmetadata-get'
+  properties: {
+    displayName: 'OAuth Metadata Get'
+    method: 'GET'
+    urlTemplate: '/.well-known/oauth-authorization-server'
+    description: 'OAuth 2.0 metadata endpoint'
+  }
+}
+
+// Add policy for the OAuth metadata get operation
+resource oauthMetadataGetPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2021-08-01' = {
+  parent: oauthMetadataGetOperation
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: loadTextContent('oauthmetadata-get.policy.xml')
+  }
+}
+
+output apiId string = oauthApi.id

--- a/labs/mcp-client-authorization/src/apim-oauth/oauthmetadata-get.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/oauthmetadata-get.policy.xml
@@ -1,0 +1,54 @@
+<!--
+    OAUTH METADATA POLICY
+    This policy implements the OpenID Connect and OAuth 2.0 discovery endpoint (.well-known/oauth-authorization-server).
+-->
+<policies>
+    <inbound>
+        <!-- Return the OAuth metadata in JSON format -->
+        <return-response>
+            <set-status code="200" reason="OK" />
+            <set-header name="Content-Type" exists-action="override">
+                <value>application/json; charset=utf-8</value>
+            </set-header>
+            <set-header name="access-control-allow-origin" exists-action="override">
+                <value>*</value>
+            </set-header>                
+            <set-body>
+                {
+                    "issuer": "{{APIMGatewayURL}}",
+                    "service_documentation": "https://microsoft.com/",
+                    "authorization_endpoint": "{{APIMGatewayURL}}/authorize",
+                    "token_endpoint": "{{APIMGatewayURL}}/token",
+                    "revocation_endpoint": "{{APIMGatewayURL}}/revoke",
+                    "registration_endpoint": "{{APIMGatewayURL}}/register",
+                    "response_types_supported": [
+                        "code"
+                    ],
+                    "code_challenge_methods_supported": [
+                        "S256"
+                    ],
+                    "token_endpoint_auth_methods_supported": [
+                        "none"
+                    ],
+                    "grant_types_supported": [
+                        "authorization_code",
+                        "refresh_token"
+                    ],
+                    "revocation_endpoint_auth_methods_supported": [
+                        "client_secret_post"
+                    ]
+                }
+            </set-body>
+        </return-response>
+        <base />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/labs/mcp-client-authorization/src/apim-oauth/oauthmetadata-options.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/oauthmetadata-options.policy.xml
@@ -1,0 +1,36 @@
+<!--
+    OAUTH METADATA OPTIONS POLICY
+    This policy handles OPTIONS requests to the OAuth metadata endpoint, implementing CORS support
+    for cross-origin requests to the OAuth authorization server.
+-->
+<policies>
+    <inbound>
+        <!-- Return CORS headers for OPTIONS requests -->
+        <return-response>
+            <set-status code="200" reason="OK" />
+            <set-header name="Access-Control-Allow-Origin" exists-action="override">
+                <value>*</value>
+            </set-header>
+            <set-header name="Access-Control-Allow-Methods" exists-action="override">
+                <value>GET, OPTIONS</value>
+            </set-header>
+            <set-header name="Access-Control-Allow-Headers" exists-action="override">
+                <value>Content-Type, Authorization</value>
+            </set-header>
+            <set-header name="Access-Control-Max-Age" exists-action="override">
+                <value>86400</value>
+            </set-header>
+            <set-body />
+        </return-response>
+        <base />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/labs/mcp-client-authorization/src/apim-oauth/register-options.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/register-options.policy.xml
@@ -1,0 +1,36 @@
+<!--
+    REGISTER OPTIONS POLICY
+    This policy handles the OPTIONS pre-flight requests for the OAuth client registration endpoint.
+    It returns the appropriate CORS headers to allow cross-origin requests.
+-->
+<policies>
+    <inbound>
+        <!-- Return a 200 OK response with appropriate CORS headers -->
+        <return-response>
+            <set-status code="200" reason="OK" />
+            <set-header name="Access-Control-Allow-Origin" exists-action="override">
+                <value>*</value>
+            </set-header>
+            <set-header name="Access-Control-Allow-Methods" exists-action="override">
+                <value>GET, OPTIONS</value>
+            </set-header>
+            <set-header name="Access-Control-Allow-Headers" exists-action="override">
+                <value>Content-Type, Authorization</value>
+            </set-header>
+            <set-header name="Access-Control-Max-Age" exists-action="override">
+                <value>86400</value>
+            </set-header>
+            <set-body />
+        </return-response>
+        <base />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/labs/mcp-client-authorization/src/apim-oauth/register.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/register.policy.xml
@@ -1,0 +1,66 @@
+<!--
+    REGISTER POLICY
+    This policy implements the dynamic client registration endpoint for OAuth2 flow.
+    
+    Flow:
+    1. MCP client sends a registration request with redirect URIs
+    2. We store the registration information in cache for later verification
+    3. We generate and return client credentials with the provided redirect URIs
+-->
+<policies>
+    <inbound>
+        <base />
+        <!-- STEP 1: Extract client registration data from request -->
+        <set-variable name="requestBody" value="@(context.Request.Body.As<JObject>(preserveContent: true))" />
+          <!-- STEP 2: Store registration information in cache -->
+        <cache-store-value duration="700" 
+            key="DynamicClientRegistration" 
+            value="@(context.Variables.GetValueOrDefault<JObject>("requestBody").ToString())" />
+        
+        <!-- Store the redirect URI -->
+        <cache-store-value duration="700" 
+            key="ClientRedirectUri" 
+            value="@(context.Variables.GetValueOrDefault<JObject>("requestBody")["redirect_uris"][0].ToString())" />
+        
+        <!-- STEP 3: Set response content type -->
+        <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+        </set-header>
+        
+        <!-- STEP 4: Return client credentials response -->
+        <return-response>
+            <set-status code="200" reason="OK" />
+            <set-header name="access-control-allow-origin" exists-action="override">
+                <value>*</value>
+            </set-header>
+            <set-body template="none">@{
+                var requestBody = context.Variables.GetValueOrDefault<JObject>("requestBody");
+                
+                // Generate timestamps dynamically
+                // Current time in seconds since epoch (Unix timestamp)
+                long currentTimeSeconds = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                
+                // Client ID issued at current time
+                long clientIdIssuedAt = currentTimeSeconds;
+                
+                // Client secret expires in 1 year (31536000 seconds = 365 days)
+                long clientSecretExpiresAt = currentTimeSeconds + 31536000;
+                
+                return new JObject
+                {
+                    ["client_id"] = "{{McpClientId}}",
+                    ["client_id_issued_at"] = clientIdIssuedAt,
+                    ["client_secret_expires_at"] = clientSecretExpiresAt,
+                    ["redirect_uris"] = requestBody["redirect_uris"]?.ToObject<JArray>()
+                }.ToString();
+            }</set-body>
+        </return-response>
+    </inbound>
+    <backend />
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/labs/mcp-client-authorization/src/apim-oauth/token.policy.xml
+++ b/labs/mcp-client-authorization/src/apim-oauth/token.policy.xml
@@ -1,0 +1,151 @@
+<!--
+    TOKEN POLICY
+    This policy implements the token endpoint for PKCE OAuth2 flow.
+    
+    Flow:
+    1. MCP client sends token request with code and code_verifier
+    2. We validate the code_verifier against the stored code_challenge
+    3. We retrieve the cached access token and return it to the client
+-->
+<policies>
+    <inbound>
+        <base />
+        <!-- STEP 1: Extract parameters from token request -->
+        <!-- Read the request body as a string while preserving it for later processing -->
+        <set-variable name="tokenRequestBody" value="@((string)context.Request.Body.As<string>(preserveContent: true))" />
+        
+        <!-- Extract the confirmation code from the request -->
+        <set-variable name="mcpConfirmConsentCode" value="@{
+            // Retrieve the raw body string
+            var body = context.Variables.GetValueOrDefault<string>("tokenRequestBody");
+            if (!string.IsNullOrEmpty(body))
+            {
+                // Split the body into name/value pairs
+                var pairs = body.Split('&');
+                foreach (var pair in pairs)
+                {
+                    var keyValue = pair.Split('=');
+                    if (keyValue.Length == 2)
+                    {
+                        if(keyValue[0] == "code")
+                        {
+                            return keyValue[1];
+                        }
+                    }
+                }
+            }
+            return "";
+        }" />            
+        <!-- Extract the code_verifier from the request -->        
+         <set-variable name="mcpClientCodeVerifier" value="@{
+            // Retrieve the raw body string
+            var body = context.Variables.GetValueOrDefault<string>("tokenRequestBody");
+            if (!string.IsNullOrEmpty(body))
+            {
+                // Split the body into name/value pairs
+                var pairs = body.Split('&');
+                foreach (var pair in pairs)
+                {
+                    var keyValue = pair.Split('=');
+                    if (keyValue.Length == 2)
+                    {
+                        if(keyValue[0] == "code_verifier")
+                        {
+                            return keyValue[1];
+                        }
+                    }
+                }
+            }
+            return "";
+        }" />
+            
+            <!-- STEP 2: Extract state parameters -->
+            <set-variable name="mcpState" value="@((string)context.Request.Url.Query.GetValueOrDefault("state", ""))" />
+            <set-variable name="stateSession" value="@((string)context.Request.Url.Query.GetValueOrDefault("state_session", ""))" />        
+    </inbound>
+    <backend />
+    <outbound>
+        <base />
+        <!-- STEP 3: Retrieve stored MCP client data -->
+        <!-- Lookup the stored MCP client code challenge and challenge method from the cache -->
+        <cache-lookup-value key="@($"McpClientAuthData-{context.Variables.GetValueOrDefault("mcpConfirmConsentCode")}")" variable-name="mcpClientAuthData" />
+        
+        <!-- Extract the stored code challenge from the cached data -->
+        <set-variable name="storedMcpClientCodeChallenge" value="@{
+            var mcpAuthDataAsJObject = JObject.Parse((string)context.Variables["mcpClientAuthData"]);
+            return (string)mcpAuthDataAsJObject["mcpClientCodeChallenge"];
+        }" />            
+        <!-- STEP 4: Compute and validate the code challenge -->
+        <!-- Generate a challenge from the incoming code_verifier using the stored challenge method -->
+        <set-variable name="mcpServerComputedCodeChallenge" value="@{
+            var mcpAuthDataAsJObject = JObject.Parse((string)context.Variables["mcpClientAuthData"]);
+            string codeVerifier = (string)context.Variables.GetValueOrDefault("mcpClientCodeVerifier", "");
+            string codeChallengeMethod = ((string)mcpAuthDataAsJObject["mcpClientCodeChallengeMethod"]).ToLower();
+            
+            if(string.IsNullOrEmpty(codeVerifier)){
+                return string.Empty;
+            }
+            
+            if(codeChallengeMethod == "plain"){
+                // For "plain", no transformation is applied
+                return codeVerifier;
+            } else if(codeChallengeMethod == "s256"){
+                // For S256, compute the SHA256 hash, Base64 encode it, and convert to URL-safe format
+                using (var sha256 = System.Security.Cryptography.SHA256.Create())
+                {
+                    var bytes = System.Text.Encoding.UTF8.GetBytes(codeVerifier);
+                    var hash = sha256.ComputeHash(bytes);
+                    
+                    // Convert the hash to a Base64 string
+                    string base64 = Convert.ToBase64String(hash);
+
+                    // Convert Base64 string into a URL-safe variant
+                    // Replace '+' with '-', '/' with '_', and remove any '=' padding
+                    return base64.Replace("+", "-").Replace("/", "_").Replace("=", "");
+                }
+            } else {
+                // Unsupported method
+                return string.Empty;
+            }
+        }" />            
+        <!-- STEP 5: Verify code challenge matches -->
+        <choose>
+            <when condition="@(string.Compare((string)context.Variables.GetValueOrDefault("mcpServerComputedCodeChallenge", ""), (string)context.Variables.GetValueOrDefault("storedMcpClientCodeChallenge", "")) != 0)">
+                <!-- If they don't match, return an error -->
+                <return-response>
+                    <set-status code="400" reason="Bad Request" />
+                    <set-body>@("{\"error\": \"code_verifier does not match.\"}")</set-body>
+                </return-response>
+            </when>
+        </choose>
+        
+        <!-- STEP 6: Retrieve cached tokens -->
+        <!-- Get the access token stored during the authorization process -->
+        <cache-lookup-value key="@($"AccessToken-{context.Variables.GetValueOrDefault("mcpConfirmConsentCode")}")" variable-name="cachedSessionToken" />
+        
+        <!-- STEP 7: Generate token response -->
+        <set-variable name="jsonPayload" value="@{
+            var accessToken = context.Variables.GetValueOrDefault<string>("cachedSessionToken");
+            var payloadObject = new
+            {
+                access_token = accessToken,
+                token_type = "Bearer",
+                expires_in = 3600,
+                refresh_token = "",
+                scope = "openid profile email"
+            };
+
+            // Serialize the object to a JSON string.
+            return Newtonsoft.Json.JsonConvert.SerializeObject(payloadObject);
+        }" />
+        <set-body template="none">@{
+            return (string)context.Variables.GetValueOrDefault("jsonPayload", "");
+        }</set-body>
+        <set-header name="access-control-allow-origin" exists-action="override">
+            <value>*</value>
+        </set-header>
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>


### PR DESCRIPTION
## Purpose

* Add bicep and policy files to create OAuth endpoints in APIM automatically to the MCP Client Authorization lab. The OAuth endpoints return a generated session token to MCP Client after user login.
* Improve the coding style and add comments to the original policy
* Use Named Value to config the OAuth endpoints
* Added some additional operations (e.g. `OPTIONS /register`, `GET /.well-known/oauth-authorization-server`) to make the authorization work

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->
```text
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```text
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

```bash
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```text
Use Azure CLI or other tools to deploy `labs\mcp-client-authorization\src\apim-oauth\oauth.bicep`
```

## What to Check

Verify that the following are valid:

* Authorization endpoint works
* Register endpoint works
* Token endpoint works
* oauth callback endpoint works
* oauth metadata endpoint works

## Other Information

<!-- Add any other helpful information that may be needed here. -->
