### PR TITLE
replaced azapi_resource.apim with azurerm_api_management.apim

### DIFF
--- a/labs/backend-pool-load-balancing-tf/backend-pool-load-balancing-tf.ipynb
+++ b/labs/backend-pool-load-balancing-tf/backend-pool-load-balancing-tf.ipynb
@@ -428,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/labs/backend-pool-load-balancing-tf/clean-up-resources.ipynb
+++ b/labs/backend-pool-load-balancing-tf/clean-up-resources.ipynb
@@ -53,7 +53,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/labs/backend-pool-load-balancing-tf/output.tf
+++ b/labs/backend-pool-load-balancing-tf/output.tf
@@ -1,5 +1,5 @@
 output "apim_resource_gateway_url" {
-  value = azapi_resource.apim.output.properties.gatewayUrl
+  value = azurerm_api_management.apim.gateway_url
 }
 
 output "apim_subscription_key" {

--- a/labs/backend-pool-load-balancing-tf/providers.tf
+++ b/labs/backend-pool-load-balancing-tf/providers.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.26.0"
+      version = ">= 4.36.0"
     }
     azapi = {
       source  = "Azure/azapi"

--- a/labs/backend-pool-load-balancing-tf/terraform.tfvars
+++ b/labs/backend-pool-load-balancing-tf/terraform.tfvars
@@ -1,5 +1,5 @@
 
-resource_group_name     = "lab-backend-pool-load-balancing-tf"
+resource_group_name     = "rg-lab-backend-pool-load-balancing-tf"
 resource_group_location = "westeurope"
 apim_sku                = "BasicV2"
 openai_deployment_name  = "gpt-4o"

--- a/labs/backend-pool-load-balancing-tf/variables.tf
+++ b/labs/backend-pool-load-balancing-tf/variables.tf
@@ -1,16 +1,16 @@
 variable "resource_group_name" {
-  type        = string
-  default     = "lab-backend-pool-load-balancing-terraform"
+  type    = string
+  default = "lab-backend-pool-load-balancing-terraform"
 }
 
 variable "resource_group_location" {
-  type        = string
-  default     = "westeurope"
+  type    = string
+  default = "westeurope"
 }
 
 variable "openai_backend_pool_name" {
-  type        = string
-  default     = "openai-backend-pool"
+  type    = string
+  default = "openai-backend-pool"
 }
 
 variable "openai_config" {
@@ -37,51 +37,51 @@ variable "openai_config" {
 }
 
 variable "openai_deployment_name" {
-  type        = string
-  default     = "gpt-4o"
+  type    = string
+  default = "gpt-4o"
 }
 
 variable "openai_sku" {
-  type        = string
-  default     = "S0"
+  type    = string
+  default = "S0"
 }
 
 variable "openai_model_name" {
-  type        = string
-  default     = "gpt-4o"
+  type    = string
+  default = "gpt-4o"
 }
 
 variable "openai_model_version" {
-  type        = string
-  default     = "2024-08-06"
+  type    = string
+  default = "2024-08-06"
 }
 
 variable "openai_model_capacity" {
-  type        = number
-  default     = 8
+  type    = number
+  default = 8
 }
 
 variable "openai_api_spec_url" {
-  type        = string
-  default     = "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-10-21/inference.json"
+  type    = string
+  default = "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cognitiveservices/data-plane/AzureOpenAI/inference/stable/2024-10-21/inference.json"
 }
 
 variable "apim_resource_name" {
-  type        = string
-  default     = "apim"
+  type    = string
+  default = "apim"
 }
 
 variable "apim_resource_location" {
-  type        = string
-  default     = "westeurope" # APIM SKU StandardV2 is not yet supported in the region Sweden Central
+  type    = string
+  default = "westeurope" # APIM SKU StandardV2 is not yet supported in the region Sweden Central
 }
 
 variable "apim_sku" {
-  type        = string
-  default     = "BasicV2"
+  type    = string
+  default = "BasicV2"
 }
 
 variable "openai_api_version" {
-  type        = string
-  default     = "2024-10-21"
+  type    = string
+  default = "2024-10-21"
 }


### PR DESCRIPTION
## Purpose

AzureRM terraform provider v4.36 now supports creating APIM with V2 sku. This PR updates the terraform lab to use that.

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->
```text
[ ] Yes
[x ] No
```