### PR TITLE
Fix devcontainer for ARM64/Apple Silicon support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "AI Gateway Dev Container",
-	"image": "mcr.microsoft.com/devcontainers/universal:2",
+	// Using Python bullseye image which has ARM64 support
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
 	"hostRequirements": {
 	  "cpus": 4
 	},


### PR DESCRIPTION
## Summary
- Fixes devcontainer compatibility issues on Apple Silicon Macs (M1/M2/M3) when using DevPod with Orbstack
- Resolves "no match for platform in manifest: not found" error

## Changes
- Replaced `mcr.microsoft.com/devcontainers/universal:2` with `mcr.microsoft.com/devcontainers/python:1-3.11-bullseye`
- The Python Bullseye image has native ARM64 support, eliminating the need for emulation

## Testing
- [ ] Test devcontainer builds successfully on Apple Silicon Mac with Orbstack
- [ ] Verify all features (Azure CLI, Python, etc.) work correctly
- [ ] Confirm no regression on x86_64 systems

## Context
The universal:2 image doesn't include ARM64 manifests, causing build failures on Apple Silicon. The Python Bullseye variant provides equivalent functionality with full ARM64 support.

🤖 Generated with [Claude Code](https://claude.ai/code)