### PR TITLE
Fixing an issue with backend pool load balancing lab

### DIFF
--- a/labs/backend-pool-load-balancing/backend-pool-load-balancing.ipynb
+++ b/labs/backend-pool-load-balancing/backend-pool-load-balancing.ipynb
@@ -59,7 +59,8 @@
     "\n",
     "aiservices_config = [{\"name\": \"foundry1\", \"location\": \"eastus\", \"priority\": 1},\n",
     "                    {\"name\": \"foundry2\", \"location\": \"swedencentral\", \"priority\": 2, \"weight\": 50},\n",
-    "                    {\"name\": \"foundry3\", \"location\": \"westus\", \"priority\": 2, \"weight\": 50}]\n",
+    "                    {\"name\": \"foundry3\", \"location\": \"westus\", \"priority\": 2, \"weight\": 50},\n",
+    "                    {\"name\": \"foundry4\", \"location\": \"uksouth\", \"priority\": 3}]\n",
     "\n",
     "models_config = [{\"name\": \"gpt-4o-mini\", \"publisher\": \"OpenAI\", \"version\": \"2024-07-18\", \"sku\": \"GlobalStandard\", \"capacity\": 1}]\n",
     "\n",
@@ -188,6 +189,8 @@
     "\n",
     "You will not see HTTP 429s returned as API Management's `retry` policy will select an available backend. If no backends are viable, an HTTP 503 will be returned.\n",
     "\n",
+    "**Please allow up to 2 mins before attempting to rerun this cell**\n",
+    "\n",
     "Tip: Use the [tracing tool](../../tools/tracing.ipynb) to track the behavior of the backend pool."
    ]
   },
@@ -295,7 +298,9 @@
     "<a id='sdk'></a>\n",
     "### 🧪 Test the API using the Azure OpenAI Python SDK\n",
     "\n",
-    "Repeat the same test using the Python SDK to ensure compatibility. Note that we do not know what region served the response; we only see that we obtained a response."
+    "Repeat the same test using the Python SDK to ensure compatibility. Note that we do not know what region served the response; we only see that we obtained a response.\n",
+    "\n",
+    "**Please allow up to 2 mins before attempting to rerun this cell**"
    ]
   },
   {
@@ -355,7 +360,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "myenv",
    "language": "python",
    "name": "python3"
   },

--- a/labs/backend-pool-load-balancing/policy.xml
+++ b/labs/backend-pool-load-balancing/policy.xml
@@ -6,6 +6,8 @@
     <backend>
         <!--Set count to one less than the number of backends in the pool to try all backends until the backend pool is temporarily unavailable.-->
         <retry count="2" interval="0" first-fast-retry="true" condition="@(context.Response.StatusCode == 429 || (context.Response.StatusCode == 503 && !context.Response.StatusReason.Contains("Backend pool") && !context.Response.StatusReason.Contains("is temporarily unavailable")))">
+            <!--Switch back to same backend pool which will have automatically removed the faulty backend -->
+            <set-backend-service backend-id="{backend-id}" />
             <forward-request buffer-request-body="true" />
         </retry>
     </backend>

--- a/modules/apim/v2/inference-api.bicep
+++ b/modules/apim/v2/inference-api.bicep
@@ -127,7 +127,7 @@ resource inferenceBackend 'Microsoft.ApiManagement/service/backends@2024-06-01-p
         errorReasons: [
           'Server errors'
         ]
-        interval: 'PT5M'
+        interval: 'PT1M'
         statusCodeRanges: [
           {
           min: 429


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes the following issue:
1) when running "Test the API using a direct HTTP call", the 11th call got an 429, but it didn't retry. Just passed 429 directly to the caller. My understanding is that we want to show this 429 call shall be silently retried with a backup foundry instance and return the success result.
2) when running "Test the API using the Azure OpenAI Python SDK", the very first time is behaving correctly -> routing between foundry 2 and 3, then after 10th call, route back to foundry 1. However, what I observed is that starting the second time running this snippet, it stuck with foundry 1 (East US) forever, pausing at each 11th/21st/31st calls for 50-52 seconds. and then proceed to next batch. No call returns as error or 429, just takes ~50 seconds to complete that call. 


## Does this introduce a breaking change?

<!-- Mark one with an "x". -->
```text
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```text
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

* Test the code
Execute the backend loadbalancing lab

## Other Information

<!-- Add any other helpful information that may be needed here. -->
