### PR TITLE
Update model configuration to avoid o1-min in FinOps framework lab

### DIFF
--- a/labs/finops-framework/finops-framework.ipynb
+++ b/labs/finops-framework/finops-framework.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "models_config = [ { \"name\": \"gpt-4o-mini\", \"publisher\": \"OpenAI\", \"version\": \"2024-07-18\", \"sku\": \"GlobalStandard\", \"capacity\": 200, \"inputTokensMeterSku\": \"gpt-4o-mini-0718-Inp-glbl\", \"outputTokensMeterSku\": \"gpt-4o-mini-0718-Outp-glbl\" }, \n",
     "                { \"name\": \"gpt-4o\", \"publisher\": \"OpenAI\", \"version\": \"2024-11-20\", \"sku\": \"GlobalStandard\", \"capacity\": 200, \"inputTokensMeterSku\": \"gpt-4o-0806-Inp-glbl\", \"outputTokensMeterSku\": \"gpt-4o-0806-Outp-glbl\" },\n",
-    "                { \"name\": \"o1-mini\", \"publisher\": \"OpenAI\",  \"version\": \"2024-09-12\", \"sku\": \"GlobalStandard\", \"capacity\": 200, \"inputTokensMeterSku\": \"o1 mini input glbl\", \"outputTokensMeterSku\": \"o1 mini output glbl\"} ]\n",
+    "                { \"name\": \"gpt-4.1-mini\", \"publisher\": \"OpenAI\",  \"version\": \"2025-04-14\", \"sku\": \"GlobalStandard\", \"capacity\": 200, \"inputTokensMeterSku\": \"gpt-4.1-mini-0414-Inp-glbl\", \"outputTokensMeterSku\": \"gpt-4.1-mini-0414-Outp-glbl\"} ]\n",
     "\n",
     "apim_sku = 'Basicv2'\n",
     "apim_products_config = [{\"name\": \"platinum\", \"displayName\": \"Platinum Product\", \"tpm\": 2000, \"tokenQuota\": 1000000, \"tokenQuotaPeriod\": \"Monthly\", \"costQuota\": 15 },\n",


### PR DESCRIPTION
 Purpose

This is the fix to Issue #253  updating the model configuration to replace deprecated model from o1-mini to got-4.1-mini
* ...

## Does this introduce a breaking change?

<!-- Mark one with an "x". -->
```text
[ ] Yes
[x ] No
```

## Pull Request Type

This pull request updates the model configuration in the `labs/finops-framework/finops-framework.ipynb` notebook. The main change is the replacement of the `o1-mini` model entry with a new `gpt-4.1-mini` model, including updated metadata and meter SKUs.

**Model configuration update:**

* Replaced the `o1-mini` model configuration with a new `gpt-4.1-mini` entry, updating the model's name, version, and input/output token meter SKUs to reflect the latest available model.

<!-- Please check the one that applies to this PR using "x". -->
```text
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

```bash
git clone https://github.com/duongthaiha/AI-Gateway

```

* Test the code
Deploy the finop-framework lab labs\finops-framework\finops-framework.ipynb

```text
```

## What to Check

Verify that the following are valid:
Deployment is sucess without error model deprecated

* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
Closes #253 