### PR TITLE
Add self-hosted-ollama lab: Ollama on ACI behind APIM

### DIFF
--- a/labs/self-hosted-ollama/README.md
+++ b/labs/self-hosted-ollama/README.md
@@ -1,0 +1,40 @@
+---
+name: "Self-Hosted Ollama behind APIM"
+categories: ["Platform Capabilities"]
+services: ["Azure API Management", "Azure Container Instances", "Azure Container Registry"]
+shortDescription: "Deploy a self-hosted Ollama embedding model on ACI, exposed through APIM"
+detailedDescription: "This lab deploys a CPU-only Ollama container running the mxbai-embed-large embedding model on Azure Container Instances, with Azure API Management as the secure gateway. All embedding requests are routed through APIM using a subscription key. Based on the Ollama_in_Azure repo."
+authors: ["loreaa"]
+---
+
+# APIM ❤️ Self-Hosted Ollama
+
+## [Self-Hosted Ollama behind APIM lab](self-hosted-ollama.ipynb)
+
+This lab deploys a **CPU-only Ollama** container on **Azure Container Instances** with the `mxbai-embed-large` embedding model, fronted by **Azure API Management**.
+
+The Ollama endpoint is exposed exclusively through APIM so that every call requires a subscription key. Based on the [Ollama_in_Azure](https://github.com/sorgina13/Ollama_in_Azure) repository.
+
+### Architecture
+
+1. **Azure Container Registry (ACR)** — stores the Ollama container image
+2. **User-assigned Managed Identity** — used by ACI for authenticated ACR pulls
+3. **Azure Container Instances (ACI)** — runs the Ollama server with `mxbai-embed-large`
+4. **Azure API Management (APIM)** — fronts the ACI endpoint, requiring a subscription key for every request
+
+### Prerequisites
+
+- [Python 3.12 or later version](https://www.python.org/) installed
+- [VS Code](https://code.visualstudio.com/) installed with the [Jupyter notebook extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) enabled
+- [Python environment](https://code.visualstudio.com/docs/python/environments#_creating-environments) with the [requirements.txt](../../../requirements.txt) or run `pip install -r requirements.txt` in your terminal
+- [An Azure Subscription](https://azure.microsoft.com/free/) with [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/privileged#contributor) + [RBAC Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/privileged#role-based-access-control-administrator) or [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/privileged#owner) roles
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) installed and [Signed into your Azure subscription](https://learn.microsoft.com/cli/azure/authenticate-azure-cli-interactively)
+
+### 🚀 Get started
+
+Proceed by opening the [Jupyter notebook](self-hosted-ollama.ipynb), and follow the steps provided.
+
+### 🗑️ Clean up resources
+
+When you're finished with the lab, you should remove all your deployed resources from Azure to avoid extra charges and keep your Azure subscription uncluttered.
+Use the [clean-up-resources notebook](clean-up-resources.ipynb) for that.

--- a/labs/self-hosted-ollama/clean-up-resources.ipynb
+++ b/labs/self-hosted-ollama/clean-up-resources.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fdf23984",
+   "metadata": {},
+   "source": [
+    "### 🗑️ Clean up resources\n",
+    "\n",
+    "When you're finished with the lab, you should remove all your deployed resources from Azure to avoid extra charges and keep your Azure subscription uncluttered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e50653a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, sys\n",
+    "sys.path.insert(1, '../../shared')  # add the shared directory to the Python path\n",
+    "import utils\n",
+    "\n",
+    "deployment_name = os.path.basename(os.path.dirname(globals()['__vsc_ipynb_file__']))\n",
+    "resource_group = f\"lab-{deployment_name}\"\n",
+    "\n",
+    "utils.cleanup_resources(deployment_name, resource_group_name=resource_group)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/labs/self-hosted-ollama/main.bicep
+++ b/labs/self-hosted-ollama/main.bicep
@@ -1,0 +1,203 @@
+// ------------------
+//    PARAMETERS
+// ------------------
+
+@description('The pricing tier of the API Management service')
+param apimSku string = 'Basicv2'
+
+@description('Configuration array for APIM subscriptions')
+param apimSubscriptionsConfig array = []
+
+@description('The Ollama model to pull on startup')
+param ollamaModel string = 'mxbai-embed-large'
+
+@description('CPU cores for the ACI container')
+param aciCpu int = 2
+
+@description('Memory in GB for the ACI container')
+param aciMemoryInGB int = 8
+
+// ------------------
+//    VARIABLES
+// ------------------
+
+var resourceSuffix = uniqueString(subscription().id, resourceGroup().id)
+var apiManagementName = 'apim-${resourceSuffix}'
+var containerGroupName = 'aci-ollama-${resourceSuffix}'
+var location = resourceGroup().location
+
+// ------------------
+//    RESOURCES
+// ------------------
+
+// 1. Log Analytics Workspace
+module lawModule '../../modules/operational-insights/v1/workspaces.bicep' = {
+  name: 'lawModule'
+}
+
+// 2. Application Insights
+module appInsightsModule '../../modules/monitor/v1/appinsights.bicep' = {
+  name: 'appInsightsModule'
+  params: {
+    lawId: lawModule.outputs.id
+    customMetricsOptedInType: 'WithDimensions'
+  }
+}
+
+// 3. API Management
+module apimModule '../../modules/apim/v3/apim.bicep' = {
+  name: 'apimModule'
+  params: {
+    apiManagementName: apiManagementName
+    apimSku: apimSku
+    apimSubscriptionsConfig: apimSubscriptionsConfig
+    lawId: lawModule.outputs.id
+    appInsightsId: appInsightsModule.outputs.id
+    appInsightsInstrumentationKey: appInsightsModule.outputs.instrumentationKey
+  }
+}
+
+// 4. Azure Container Instance running Ollama (public image from Docker Hub)
+resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2023-05-01' = {
+  name: containerGroupName
+  location: location
+  properties: {
+    osType: 'Linux'
+    restartPolicy: 'Always'
+    ipAddress: {
+      type: 'Public'
+      ports: [
+        {
+          port: 11434
+          protocol: 'TCP'
+        }
+      ]
+    }
+    containers: [
+      {
+        name: 'ollama'
+        properties: {
+          image: 'ollama/ollama:latest'
+          resources: {
+            requests: {
+              cpu: aciCpu
+              memoryInGB: aciMemoryInGB
+            }
+          }
+          ports: [
+            {
+              port: 11434
+              protocol: 'TCP'
+            }
+          ]
+          environmentVariables: [
+            {
+              name: 'OLLAMA_HOST'
+              value: '0.0.0.0:11434'
+            }
+          ]
+          command: [
+            '/bin/sh'
+            '-c'
+            'ollama serve & sleep 15 && ollama pull ${ollamaModel} && wait'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+// 5. APIM Backend pointing to ACI public IP
+resource apimService 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
+  name: apiManagementName
+}
+
+resource ollamaBackend 'Microsoft.ApiManagement/service/backends@2024-06-01-preview' = {
+  parent: apimService
+  name: 'ollama-backend'
+  properties: {
+    protocol: 'http'
+    url: 'http://${containerGroup.properties.ipAddress.ip}:11434/v1'
+    description: 'Self-hosted Ollama on ACI'
+  }
+}
+
+// 6. APIM API for Ollama (OpenAI-compatible)
+resource ollamaApi 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
+  parent: apimService
+  name: 'ollama-inference'
+  properties: {
+    apiType: 'http'
+    description: 'Self-hosted Ollama Embeddings API'
+    displayName: 'Ollama Inference'
+    path: 'ollama'
+    protocols: [
+      'https'
+    ]
+    subscriptionKeyParameterNames: {
+      header: 'api-key'
+      query: 'api-key'
+    }
+    subscriptionRequired: true
+    type: 'http'
+  }
+}
+
+// 7. Catch-all POST operation so any sub-path is forwarded
+resource ollamaApiPostOp 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  parent: ollamaApi
+  name: 'post-all'
+  properties: {
+    displayName: 'POST Catch All'
+    method: 'POST'
+    urlTemplate: '/{*path}'
+    templateParameters: [
+      {
+        name: 'path'
+        required: true
+        type: 'string'
+      }
+    ]
+  }
+}
+
+// 7b. Catch-all GET operation (for model listing, health checks)
+resource ollamaApiGetOp 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  parent: ollamaApi
+  name: 'get-all'
+  properties: {
+    displayName: 'GET Catch All'
+    method: 'GET'
+    urlTemplate: '/{*path}'
+    templateParameters: [
+      {
+        name: 'path'
+        required: true
+        type: 'string'
+      }
+    ]
+  }
+}
+
+// 8. API-level policy
+resource ollamaApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-01-preview' = {
+  parent: ollamaApi
+  name: 'policy'
+  properties: {
+    format: 'rawxml'
+    value: loadTextContent('policy.xml')
+  }
+  dependsOn: [
+    ollamaBackend
+  ]
+}
+
+// ------------------
+//    OUTPUTS
+// ------------------
+
+output logAnalyticsWorkspaceId string = lawModule.outputs.customerId
+output apimServiceId string = apimModule.outputs.id
+output apimResourceGatewayURL string = apimModule.outputs.gatewayUrl
+output apimSubscriptions array = apimModule.outputs.apimSubscriptions
+output aciPublicIP string = containerGroup.properties.ipAddress.ip

--- a/labs/self-hosted-ollama/policy.xml
+++ b/labs/self-hosted-ollama/policy.xml
@@ -1,0 +1,15 @@
+<policies>
+    <inbound>
+        <base />
+        <set-backend-service backend-id="ollama-backend" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/labs/self-hosted-ollama/self-hosted-ollama.ipynb
+++ b/labs/self-hosted-ollama/self-hosted-ollama.ipynb
@@ -1,0 +1,408 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "93bb8f80",
+   "metadata": {},
+   "source": [
+    "# APIM ❤️ Self-Hosted Ollama\n",
+    "\n",
+    "## Self-Hosted Ollama behind APIM lab\n",
+    "\n",
+    "This lab deploys a **CPU-only Ollama** container on **Azure Container Instances** with the `mxbai-embed-large` embedding model, fronted by **Azure API Management**.\n",
+    "The Ollama endpoint is exposed exclusively through APIM so that every call requires a subscription key.\n",
+    "\n",
+    "Based on the [Ollama_in_Azure](https://github.com/sorgina13/Ollama_in_Azure) repository.\n",
+    "\n",
+    "### Prerequisites\n",
+    "\n",
+    "- [Python 3.12 or later version](https://www.python.org/) installed\n",
+    "- [VS Code](https://code.visualstudio.com/) installed with the [Jupyter notebook extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) enabled\n",
+    "- [Python environment](https://code.visualstudio.com/docs/python/environments#_creating-environments) with the [requirements.txt](../../../requirements.txt) or run `pip install -r requirements.txt` in your terminal\n",
+    "- [An Azure Subscription](https://azure.microsoft.com/free/) with [Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/privileged#contributor) + [RBAC Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/privileged#role-based-access-control-administrator) or [Owner](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/privileged#owner) roles\n",
+    "- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) installed and [Signed into your Azure subscription](https://learn.microsoft.com/cli/azure/authenticate-azure-cli-interactively)\n",
+    "\n",
+    "▶️ Click `Run All` to execute all steps sequentially, or execute them `Step by Step`..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eef43fc3",
+   "metadata": {},
+   "source": [
+    "<a id='0'></a>\n",
+    "### 0️⃣ Initialize Variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "7f03d6d3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "✅ \u001b[1;32mNotebook initialized\u001b[0m ⌚ 14:02:12.591776 \n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, sys, json\n",
+    "sys.path.insert(1, '../../shared')  # add the shared directory to the Python path\n",
+    "import utils\n",
+    "\n",
+    "deployment_name = os.path.basename(os.path.dirname(globals()['__vsc_ipynb_file__']))\n",
+    "resource_group_name = f\"lab-{deployment_name}\"\n",
+    "resource_group_location = \"eastus2\"\n",
+    "\n",
+    "# APIM configuration\n",
+    "apim_sku = 'Basicv2'\n",
+    "apim_subscriptions_config = [{\"name\": \"subscription1\", \"displayName\": \"Subscription 1\"}]\n",
+    "\n",
+    "# Ollama container configuration (uses public ollama/ollama:latest from Docker Hub)\n",
+    "ollama_model = 'mxbai-embed-large'\n",
+    "aci_cpu = 2\n",
+    "aci_memory = 8\n",
+    "\n",
+    "utils.print_ok('Notebook initialized')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5511593d",
+   "metadata": {},
+   "source": [
+    "<a id='1'></a>\n",
+    "### 1️⃣ Verify the Azure CLI and the connected Azure subscription\n",
+    "\n",
+    "The following commands ensure that you have the latest version of the Azure CLI and that the Azure CLI is connected to your Azure subscription."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "05f9accf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "⚙️ \u001b[1;34mRunning: az account show \u001b[0m\n",
+      "✅ \u001b[1;32mRetrieved az account\u001b[0m ⌚ 13:22:17.007768 [0m:2s]\n",
+      "👉🏽 \u001b[1;34mCurrent user: loreaa@MngEnvMCAP012005.onmicrosoft.com\u001b[0m\n",
+      "👉🏽 \u001b[1;34mTenant ID: 1ab8ab01-0a1e-4553-bb73-b746626497c0\u001b[0m\n",
+      "👉🏽 \u001b[1;34mSubscription ID: 325177b6-ea0e-4cae-9862-db57a44eee60\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "output = utils.run(\"az account show\", \"Retrieved az account\", \"Failed to get the current az account\")\n",
+    "\n",
+    "if output.success and output.json_data:\n",
+    "    current_user = output.json_data['user']['name']\n",
+    "    tenant_id = output.json_data['tenantId']\n",
+    "    subscription_id = output.json_data['id']\n",
+    "\n",
+    "    utils.print_info(f\"Current user: {current_user}\")\n",
+    "    utils.print_info(f\"Tenant ID: {tenant_id}\")\n",
+    "    utils.print_info(f\"Subscription ID: {subscription_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e61efd5",
+   "metadata": {},
+   "source": [
+    "<a id='2'></a>\n",
+    "### 2️⃣ Create deployment using 🦾 Bicep\n",
+    "\n",
+    "This step creates the resource group and deploys the full infrastructure using [main.bicep](main.bicep):\n",
+    "- **APIM** (Basicv2) as the secure gateway\n",
+    "- **ACI** running the public `ollama/ollama:latest` image from Docker Hub (no ACR build needed)\n",
+    "- **APIM Backend + API** wiring to forward requests to Ollama on ACI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "108b4a0c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "⚙️ \u001b[1;34mRunning: az group show --name lab-self-hosted-ollama \u001b[0m\n",
+      "👉🏽 \u001b[1;34mUsing existing resource group 'lab-self-hosted-ollama'\u001b[0m\n",
+      "👉🏽 \u001b[1;34mBicep parameters written to params.json\u001b[0m\n",
+      "⚙️ \u001b[1;34mRunning: az deployment group create --name self-hosted-ollama --resource-group lab-self-hosted-ollama --template-file main.bicep --parameters params.json \u001b[0m\n",
+      "✅ \u001b[1;32mDeployment 'self-hosted-ollama' succeeded\u001b[0m ⌚ 14:09:59.911712 [1m:43s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create the resource group\n",
+    "utils.create_resource_group(resource_group_name, resource_group_location)\n",
+    "\n",
+    "# Define Bicep parameters\n",
+    "bicep_parameters = {\n",
+    "    \"$schema\": \"https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#\",\n",
+    "    \"contentVersion\": \"1.0.0.0\",\n",
+    "    \"parameters\": {\n",
+    "        \"apimSku\": { \"value\": apim_sku },\n",
+    "        \"apimSubscriptionsConfig\": { \"value\": apim_subscriptions_config },\n",
+    "        \"ollamaModel\": { \"value\": ollama_model },\n",
+    "        \"aciCpu\": { \"value\": aci_cpu },\n",
+    "        \"aciMemoryInGB\": { \"value\": aci_memory },\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "with open('params.json', 'w') as f:\n",
+    "    f.write(json.dumps(bicep_parameters))\n",
+    "\n",
+    "utils.print_info('Bicep parameters written to params.json')\n",
+    "\n",
+    "# Deploy everything in a single step (uses public ollama/ollama:latest image from Docker Hub)\n",
+    "output = utils.run(\n",
+    "    f\"az deployment group create --name {deployment_name} --resource-group {resource_group_name} \"\n",
+    "    f\"--template-file main.bicep --parameters params.json\",\n",
+    "    f\"Deployment '{deployment_name}' succeeded\",\n",
+    "    f\"Deployment '{deployment_name}' failed\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42ec0aeb",
+   "metadata": {},
+   "source": [
+    "<a id='3'></a>\n",
+    "### 3️⃣ Get the deployment outputs\n",
+    "\n",
+    "Retrieve the APIM gateway URL and subscription key needed for testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "d9fb9833",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "⚙️ \u001b[1;34mRunning: az deployment group show --name self-hosted-ollama -g lab-self-hosted-ollama \u001b[0m\n",
+      "✅ \u001b[1;32mRetrieved deployment: self-hosted-ollama\u001b[0m ⌚ 14:10:10.828774 [0m:3s]\n",
+      "👉🏽 \u001b[1;34mLog Analytics Id: 3c22bd92-8f0e-4ca9-ad61-cf274bc20aec\u001b[0m\n",
+      "👉🏽 \u001b[1;34mAPIM Service Id: /subscriptions/325177b6-ea0e-4cae-9862-db57a44eee60/resourceGroups/lab-self-hosted-ollama/providers/Microsoft.ApiManagement/service/apim-7sgnnlfokqvt4\u001b[0m\n",
+      "👉🏽 \u001b[1;34mAPIM API Gateway URL: https://apim-7sgnnlfokqvt4.azure-api.net\u001b[0m\n",
+      "👉🏽 \u001b[1;34mACI Public IP: 52.177.251.233\u001b[0m\n",
+      "👉🏽 \u001b[1;34mSubscription Name: subscription1\u001b[0m\n",
+      "👉🏽 \u001b[1;34mSubscription Key: ****72f2\u001b[0m\n",
+      "👉🏽 \u001b[1;34mOllama via APIM: https://apim-7sgnnlfokqvt4.azure-api.net/ollama\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "output = utils.run(\n",
+    "    f\"az deployment group show --name {deployment_name} -g {resource_group_name}\",\n",
+    "    f\"Retrieved deployment: {deployment_name}\",\n",
+    "    f\"Failed to retrieve deployment: {deployment_name}\")\n",
+    "\n",
+    "if output.success and output.json_data:\n",
+    "    log_analytics_id = utils.get_deployment_output(output, 'logAnalyticsWorkspaceId', 'Log Analytics Id')\n",
+    "    apim_service_id = utils.get_deployment_output(output, 'apimServiceId', 'APIM Service Id')\n",
+    "    apim_resource_gateway_url = utils.get_deployment_output(output, 'apimResourceGatewayURL', 'APIM API Gateway URL')\n",
+    "    aci_public_ip = utils.get_deployment_output(output, 'aciPublicIP', 'ACI Public IP')\n",
+    "    apim_subscriptions = json.loads(utils.get_deployment_output(output, 'apimSubscriptions').replace(\"\\'\", '\"'))\n",
+    "    for subscription in apim_subscriptions:\n",
+    "        subscription_name = subscription['name']\n",
+    "        subscription_key = subscription['key']\n",
+    "        utils.print_info(f\"Subscription Name: {subscription_name}\")\n",
+    "        utils.print_info(f\"Subscription Key: ****{subscription_key[-4:]}\")\n",
+    "    api_key = apim_subscriptions[0].get('key')\n",
+    "\n",
+    "    # Build the APIM base URL for Ollama\n",
+    "    apim_ollama_base_url = f\"{apim_resource_gateway_url}/ollama\"\n",
+    "    utils.print_info(f\"Ollama via APIM: {apim_ollama_base_url}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81c9d8d9",
+   "metadata": {},
+   "source": [
+    "<a id='4'></a>\n",
+    "### 4️⃣ Wait for Ollama to be ready\n",
+    "\n",
+    "The ACI container needs to download the embedding model on first boot. This step polls until the model is available."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "341b7d81",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "👉🏽 \u001b[1;34mWaiting for Ollama model to be ready (this can take a few minutes on first boot)...\u001b[0m\n",
+      "✅ \u001b[1;32mOllama is ready with model: ['mxbai-embed-large:latest']\u001b[0m ⌚ 14:07:09.731106 \n"
+     ]
+    }
+   ],
+   "source": [
+    "import time, requests\n",
+    "\n",
+    "utils.print_info('Waiting for Ollama model to be ready (this can take a few minutes on first boot)...')\n",
+    "\n",
+    "max_attempts = 30\n",
+    "for attempt in range(1, max_attempts + 1):\n",
+    "    try:\n",
+    "        r = requests.get(f'http://{aci_public_ip}:11434/api/tags', timeout=10)\n",
+    "        if r.status_code == 200:\n",
+    "            models = r.json().get('models', [])\n",
+    "            model_names = [m.get('name', '') for m in models]\n",
+    "            if any(ollama_model in name for name in model_names):\n",
+    "                utils.print_ok(f'Ollama is ready with model: {model_names}')\n",
+    "                break\n",
+    "            else:\n",
+    "                utils.print_info(f'Attempt {attempt}/{max_attempts}: Model not yet available. Models: {model_names}')\n",
+    "        else:\n",
+    "            utils.print_info(f'Attempt {attempt}/{max_attempts}: HTTP {r.status_code}')\n",
+    "    except Exception as e:\n",
+    "        utils.print_info(f'Attempt {attempt}/{max_attempts}: {e}')\n",
+    "    time.sleep(20)\n",
+    "else:\n",
+    "    utils.print_error('Ollama did not become ready in time. Check ACI logs with:')\n",
+    "    utils.print_info(f'  az container logs -g {resource_group_name} -n <container-name>')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c86183bc",
+   "metadata": {},
+   "source": [
+    "<a id='test'></a>\n",
+    "### 🧪 Test embeddings through APIM\n",
+    "\n",
+    "This test cell reuses the logic from [`olama.py`](https://github.com/sorgina13/Ollama_in_Azure/blob/main/olama.py) but routes all traffic through the APIM gateway using the subscription key.\n",
+    "\n",
+    "Tip: Use the [tracing tool](../../../tools/tracing.ipynb) to track the behavior and troubleshoot the [policy](policy.xml)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "18d8b939",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🧠 Generating embeddings via APIM → Ollama (mxbai-embed-large)...\n",
+      "\n",
+      "🔍 Query: Where is the lab located?\n",
+      "------------------------------\n",
+      "[0.5900] Mixbread AI is a research lab based in Germany.\n",
+      "[0.4389] Agentic workflows require high-precision retrieval layers.\n",
+      "[0.4380] Ollama allows you to run LLMs and embedding models locally.\n",
+      "[0.3852] The mxbai-embed-large model has 335 million parameters.\n",
+      "✅ \u001b[1;32mEmbedding test through APIM completed successfully!\u001b[0m ⌚ 14:10:47.570407 \n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "# ---------- Connect through APIM instead of directly to ACI ----------\n",
+    "client = OpenAI(\n",
+    "    base_url=apim_ollama_base_url,   # APIM gateway URL + /ollama\n",
+    "    api_key=\"placeholder\",            # Required by SDK but not used\n",
+    "    default_headers={\"api-key\": api_key}  # APIM subscription key\n",
+    ")\n",
+    "\n",
+    "# ---------- Sample documents (from olama.py) ----------\n",
+    "documents = [\n",
+    "    \"Mixbread AI is a research lab based in Germany.\",\n",
+    "    \"The mxbai-embed-large model has 335 million parameters.\",\n",
+    "    \"Ollama allows you to run LLMs and embedding models locally.\",\n",
+    "    \"Agentic workflows require high-precision retrieval layers.\"\n",
+    "]\n",
+    "\n",
+    "def get_embedding(text, is_query=False):\n",
+    "    prefix = \"Represent this sentence for searching relevant passages:\\n\" if is_query else \"\"\n",
+    "    response = client.embeddings.create(\n",
+    "        model=\"mxbai-embed-large\",\n",
+    "        input=prefix + text\n",
+    "    )\n",
+    "    return response.data[0].embedding\n",
+    "\n",
+    "def cosine_similarity(v1, v2):\n",
+    "    return np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))\n",
+    "\n",
+    "# ---------- Generate embeddings via APIM → Ollama ----------\n",
+    "print(\"🧠 Generating embeddings via APIM → Ollama (mxbai-embed-large)...\")\n",
+    "doc_vectors = [get_embedding(doc) for doc in documents]\n",
+    "\n",
+    "query = \"Where is the lab located?\"\n",
+    "query_vector = get_embedding(query, is_query=True)\n",
+    "\n",
+    "print(f\"\\n🔍 Query: {query}\")\n",
+    "print(\"-\" * 30)\n",
+    "\n",
+    "results = []\n",
+    "for i, doc_vec in enumerate(doc_vectors):\n",
+    "    score = cosine_similarity(query_vector, doc_vec)\n",
+    "    results.append((score, documents[i]))\n",
+    "\n",
+    "results.sort(key=lambda x: x[0], reverse=True)\n",
+    "\n",
+    "for score, text in results:\n",
+    "    print(f\"[{score:.4f}] {text}\")\n",
+    "\n",
+    "utils.print_ok('Embedding test through APIM completed successfully!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d87df129",
+   "metadata": {},
+   "source": [
+    "<a id='clean'></a>\n",
+    "### 🗑️ Clean up resources\n",
+    "\n",
+    "When you're finished with the lab, you should remove all your deployed resources from Azure to avoid extra charges and keep your Azure subscription uncluttered.\n",
+    "Use the [clean-up-resources notebook](clean-up-resources.ipynb) for that."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "3.12.10",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## New Lab: Self-Hosted Ollama

Deploys a CPU-only Ollama container (mxbai-embed-large) on **Azure Container Instances**, fronted by **Azure API Management**.

### Highlights
- Uses the public ollama/ollama:latest image from Docker Hub — no ACR build needed
- Single Bicep deployment (LAW → AppInsights → APIM → ACI → Backend → API → Policy)
- APIM Basicv2 SKU with subscription key authentication
- Embedding test cell with cosine similarity search using the OpenAI SDK

### Files
| File | Description |
|------|-------------|
| \main.bicep\ | Infrastructure-as-code for all resources |
| \policy.xml\ | APIM inbound policy routing to Ollama backend |
| \self-hosted-ollama.ipynb\ | Main lab notebook (deploy + test) |
| \clean-up-resources.ipynb\ | Cleanup notebook |
| \README.md\ | Lab documentation |

Based on [Ollama_in_Azure](https://github.com/sorgina13/Ollama_in_Azure).