### PR TITLE
docs: fix MCP PRM notebook link

### DIFF
--- a/labs/mcp-prm-oauth/mcp-prm-oauth.ipynb
+++ b/labs/mcp-prm-oauth/mcp-prm-oauth.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "In this flow, Azure API Management act both as an OAuth client connecting to the [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/architecture/auth-oauth2) authorization server and as an OAuth authorization server for the MCP client ([MCP inspector](https://modelcontextprotocol.io/docs/tools/inspector) in this lab), VS Code or Copilot Studio.\n",
     "\n",
-    "Full documentation of the assets created in this lab and how they interact is documented in [Arch decisions summary](ARCH_SUMMARY.md) and in [MCP PRM Server implementation](src/mcp-prm-server/README.md)\n",
+    "Full documentation of the assets created in this lab and how they interact is documented in [Arch decisions summary](ARCH_SUMMARY.md) and in [MCP PRM Server implementation](../../shared/mcp-servers/prm-graphapi/README.md)\n",
     "\n",
     "\n",
     "⚠️ This lab implements the [MCP Authorization proposal](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) and [RFC9729](https://datatracker.ietf.org/doc/html/rfc9728), this is as close to production-grade security for MCP servers as it gets, and is inspired by the amazing work by [blackchoey/remote-mcp-apim-oauth-prm](https://github.com/blackchoey/remote-mcp-apim-oauth-prm) - originally written in C#\n",


### PR DESCRIPTION
## Problem

Azure-Samples/AI-Gateway#232 reported that the MCP PRM Server implementation link pointed at a missing `src/mcp-prm-server/README.md` path. The lab README has since been corrected, but the same broken link still remained in the matching notebook introduction.

## Solution

Updated the notebook's MCP PRM Server implementation link to the existing shared implementation docs at `../../shared/mcp-servers/prm-graphapi/README.md`, matching the current lab README.

## Validation

- `python3 -m json.tool labs/mcp-prm-oauth/mcp-prm-oauth.ipynb`
- `test -f shared/mcp-servers/prm-graphapi/README.md`
- `git diff --check`
- Confirmed no open PR currently targets `mcp-prm-server` link cleanup.

## Confidence

Score: 82/100
Category: docs/broken-link

Related: Azure-Samples/AI-Gateway#232
