### PR TITLE
fix: update MCP Inspector authorization flow to reflect PRM resource id (+instructions)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,8 @@
 	  "vscode": {
 		"extensions": [
 		  "ms-toolsai.jupyter",
-		  "ms-python.python"
+		  "ms-python.python",
+		  "ms-azuretools.vscode-bicep"
 		]
 	  }
 	}

--- a/labs/mcp-prm-oauth/clean-up-resources.ipynb
+++ b/labs/mcp-prm-oauth/clean-up-resources.ipynb
@@ -22,13 +22,25 @@
     "deployment_name = os.path.basename(os.path.dirname(globals()['__vsc_ipynb_file__']))\n",
     "resource_group = f\"lab-{deployment_name}\"\n",
     "\n",
-    "utils.cleanup_resources(deployment_name, resource_group_name=resource_group)"
+    "utils.cleanup_resources(deployment_name, resource_group_name=resource_group)\n",
+    "\n",
+    "# The lab also creates an Entra ID app registration for the MCP endpoint (when you don't bring your own `mcpClientId`). It lives in Microsoft Entra ID, not in the resource group, so it must be deleted separately.\n",
+    "\n",
+    "app_registration_name = f\"lab-{deployment_name}-app\"\n",
+    "\n",
+    "print(f\"Searching for app with display name {app_registration_name}...\")\n",
+    "output = utils.run(f\"az ad app list --filter \\\"displayName eq '{app_registration_name}'\\\"\", \"Retrieved app registration\", \"Failed to get the app registration\")\n",
+    "if output.success and output.json_data:\n",
+    "    client_id = output.json_data[0]['appId']\n",
+    "    output = utils.run(f\"az ad app delete --id {client_id}\", \"Deleted app registration\", \"Failed to delete the app registration\")\n",
+    "else:\n",
+    "    print(f\"No app registration found with display name {app_registration_name}. Nothing to delete.\")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myenv",
+   "display_name": "ai-gateway (3.12.13.final.0)",
    "language": "python",
    "name": "python3"
   },
@@ -42,7 +54,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.12.-1"
   }
  },
  "nbformat": 4,

--- a/labs/mcp-prm-oauth/main.bicep
+++ b/labs/mcp-prm-oauth/main.bicep
@@ -215,6 +215,18 @@ resource mcpServerContainerApp 'Microsoft.App/containerApps@2023-11-02-preview' 
 }
 
 // 9. Entra ID Application Registration for MCP endpoint
+// NOTE: The Microsoft Graph Bicep extension is experimental and may not be available in all environments.
+// If the deployment fails due to Graph extension issues, you have two options:
+//   1. Create the Entra App manually and provide the mcpClientId parameter
+//   2. Use Azure CLI or PowerShell scripts to create the app registration
+// 
+// To create manually:
+//   - Create an App Registration in Entra ID
+//   - Add API permission: user_impersonate (delegated)
+//   - Add ApplicationID URI: https://<apimfqdn>/${mcpApiPath}/mcp
+//   - Add redirect URI: https://{containerAppFQDN}/auth/callback
+//   - Create a federated credential trusting the managed identity
+//   - Pass the App ID as mcpClientId parameter
 module mcpEntraAppModule 'src/bicep/identity/mcp-entra-app.bicep' = if (empty(mcpClientId)) {
   name: 'mcpEntraAppModule'
   params: {

--- a/labs/mcp-prm-oauth/main.bicep
+++ b/labs/mcp-prm-oauth/main.bicep
@@ -234,6 +234,8 @@ module mcpEntraAppModule 'src/bicep/identity/mcp-entra-app.bicep' = if (empty(mc
     tenantId: subscription().tenantId
     userAssignedIdentityPrincipleId: managedIdentityModule.outputs.identityPrincipalId
     webAppName: mcpServerContainerApp.name
+    // Application ID URI == PRM resource == JWT audience (all resolve to https://<apim>.azure-api.net/<mcpPrmPath>)
+    applicationIdUri: '${apimModule.outputs.gatewayUrl}/${mcpPrmPath}'
   }
 }
 

--- a/labs/mcp-prm-oauth/main.bicep
+++ b/labs/mcp-prm-oauth/main.bicep
@@ -32,7 +32,7 @@ param tags object = {}
 
 param location string = resourceGroup().location
 
-param mcpPrmPath string = 'mcp'
+param mcpApiPath string = 'mcp'
 
 // ------------------
 //    VARIABLES
@@ -60,7 +60,7 @@ module appInsightsModule '../../modules/monitor/v1/appinsights.bicep' = {
 }
 
 // 3. API Management
-module apimModule '../../modules/apim/v2/apim.bicep' = {
+module apimModule '../../modules/apim/v4/apim.bicep' = {
   name: 'apimModule'
   params: {
     apimSku: apimSku
@@ -71,7 +71,7 @@ module apimModule '../../modules/apim/v2/apim.bicep' = {
   }
 }
 
-resource apimService 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
+resource apimService 'Microsoft.ApiManagement/service@2025-09-01-preview' existing = {
   name: 'apim-${resourceSuffix}'
   dependsOn: [
     apimModule
@@ -214,28 +214,16 @@ resource mcpServerContainerApp 'Microsoft.App/containerApps@2023-11-02-preview' 
   ]
 }
 
-// 9. Entra ID Application Registration for MCP
-// NOTE: The Microsoft Graph Bicep extension is experimental and may not be available in all environments.
-// If the deployment fails due to Graph extension issues, you have two options:
-//   1. Create the Entra App manually and provide the mcpClientId parameter
-//   2. Use Azure CLI or PowerShell scripts to create the app registration
-// 
-// To create manually:
-//   - Create an App Registration in Entra ID
-//   - Add API permission: user_impersonate (delegated)
-//   - Add redirect URI: https://{containerAppFQDN}/auth/callback
-//   - Create a federated credential trusting the managed identity
-//   - Pass the App ID as mcpClientId parameter
+// 9. Entra ID Application Registration for MCP endpoint
 module mcpEntraAppModule 'src/bicep/identity/mcp-entra-app.bicep' = if (empty(mcpClientId)) {
   name: 'mcpEntraAppModule'
   params: {
     mcpAppUniqueName: mcpEntraAppName
     mcpAppDisplayName: mcpEntraAppName
     tenantId: subscription().tenantId
-    userAssignedIdentityPrincipleId: managedIdentityModule.outputs.identityPrincipalId
     webAppName: mcpServerContainerApp.name
-    // Application ID URI == PRM resource == JWT audience (all resolve to https://<apim>.azure-api.net/<mcpPrmPath>)
-    applicationIdUri: '${apimModule.outputs.gatewayUrl}/${mcpPrmPath}'
+    userAssignedIdentityPrincipleId: managedIdentityModule.outputs.identityPrincipalId
+    applicationIdUri: '${apimModule.outputs.gatewayUrl}/${mcpApiPath}/mcp'
   }
 }
 
@@ -247,7 +235,7 @@ module mcpApiModule 'src/bicep/apim-mcp/mcp-api.bicep' = {
     webAppName: mcpServerContainerApp.name
     mcpAppId: !empty(mcpClientId) ? mcpClientId : (mcpEntraAppModule.?outputs.mcpAppId ?? '')
     mcpAppTenantId: subscription().tenantId
-    mcpApiPath: mcpPrmPath
+    mcpApiPath: mcpApiPath
   }
 }
 
@@ -299,5 +287,5 @@ output mcpServerURL string = 'https://${mcpServerContainerApp.properties.configu
 // MCP Configuration
 output mcpAppId string = !empty(mcpClientId) ? mcpClientId : (mcpEntraAppModule.?outputs.mcpAppId ?? 'Not created - provide mcpClientId parameter')
 output mcpAppTenantId string = subscription().tenantId
-output mcpApiEndpoint string = '${apimModule.outputs.gatewayUrl}/${mcpPrmPath}'
-output mcpPrmEndpoint string = '${apimModule.outputs.gatewayUrl}/${mcpPrmPath}/.well-known/oauth-protected-resource'
+output mcpApiEndpoint string = '${apimModule.outputs.gatewayUrl}/${mcpApiPath}/mcp'
+output mcpPrmEndpoint string = '${apimModule.outputs.gatewayUrl}/.well-known/oauth-protected-resource/${mcpApiPath}/mcp'

--- a/labs/mcp-prm-oauth/mcp-prm-oauth.ipynb
+++ b/labs/mcp-prm-oauth/mcp-prm-oauth.ipynb
@@ -149,7 +149,7 @@
     "        \"inferenceAPIType\": { \"value\": inference_api_type },\n",
     "        \"foundryProjectName\": { \"value\": foundry_project_name },\n",
     "        \"oauthScopes\": { \"value\": oauth_scopes },\n",
-    "        \"mcpApiPath\": { \"value\": mcpApiPath },\n",
+    "        \"mcpApiPath\": { \"value\": mcpApiPath },  ## Add a path you would like your MCP server to exposed as ##\n",
     "        \"encryptionIV\": { \"value\": encryption_iv },\n",
     "        \"encryptionKey\": { \"value\": encryption_key },\n",
     "    }\n",

--- a/labs/mcp-prm-oauth/mcp-prm-oauth.ipynb
+++ b/labs/mcp-prm-oauth/mcp-prm-oauth.ipynb
@@ -56,8 +56,9 @@
     "import utils\n",
     "\n",
     "deployment_name = os.path.basename(os.path.dirname(globals()['__vsc_ipynb_file__']))\n",
-    "resource_group_name = f\"lab-{deployment_name}\" # change the name to match your naming style\n",
+    "resource_group_name = f\"lab-{deployment_name}-4\" # change the name to match your naming style\n",
     "resource_group_location = \"ukwest\"\n",
+    "resource_suffix = ''.join(random.choices(string.ascii_letters + string.digits, k=8)).lower()\n",
     "\n",
     "aiservices_config = []\n",
     "\n",
@@ -71,8 +72,7 @@
     "inference_api_version = \"2025-03-01-preview\"\n",
     "foundry_project_name = deployment_name\n",
     "\n",
-    "# Generate a unique name for the app registration\n",
-    "app_registration_name = f\"lab-{deployment_name}-{''.join(random.choices(string.ascii_letters + string.digits, k=8)).lower()}-app\"\n",
+    "app_registration_name = f\"lab-{deployment_name}-{resource_suffix}-app\"\n",
     "\n",
     "build = 0\n",
     "prm_mcp_server_image = \"mcp-prm-server\"\n",
@@ -83,8 +83,9 @@
     "encryption_iv = base64.b64encode(os.urandom(16)).decode('utf-8')\n",
     "encryption_key = base64.b64encode(os.urandom(16)).decode('utf-8')\n",
     "oauth_scopes = 'openid https://graph.microsoft.com/.default'\n",
+    "mcpApiPath = \"profile\"  # path to the MCP API in the APIM service\n",
     "\n",
-    "utils.print_ok('Notebook initialized')"
+    "utils.print_ok('Notebook initialized')\n"
    ]
   },
   {
@@ -142,13 +143,13 @@
     "        \"mcpEntraAppName\": { \"value\": app_registration_name },\n",
     "        \"apimSku\": { \"value\": apim_sku },\n",
     "        \"aiServicesConfig\": { \"value\": aiservices_config },\n",
-    "        #\"mcpPrmPath\": { \"value\": mcpPrmPath }, ## Add a path you would like your MCP server to exposed as ##\n",
     "        \"modelsConfig\": { \"value\": models_config },\n",
     "        \"apimSubscriptionsConfig\": { \"value\": apim_subscriptions_config },\n",
     "        \"inferenceAPIPath\": { \"value\": inference_api_path },\n",
     "        \"inferenceAPIType\": { \"value\": inference_api_type },\n",
     "        \"foundryProjectName\": { \"value\": foundry_project_name },\n",
     "        \"oauthScopes\": { \"value\": oauth_scopes },\n",
+    "        \"mcpApiPath\": { \"value\": mcpApiPath },\n",
     "        \"encryptionIV\": { \"value\": encryption_iv },\n",
     "        \"encryptionKey\": { \"value\": encryption_key },\n",
     "    }\n",
@@ -160,7 +161,7 @@
     "\n",
     "# Run the deployment\n",
     "output = utils.run(f\"az deployment group create --name {deployment_name} --resource-group {resource_group_name} --template-file main.bicep --parameters params.json\",\n",
-    "    f\"Deployment '{deployment_name}' succeeded\", f\"Deployment '{deployment_name}' failed\")"
+    "    f\"Deployment '{deployment_name}' succeeded\", f\"Deployment '{deployment_name}' failed\")\n"
    ]
   },
   {
@@ -255,7 +256,7 @@
     "# Unauthenticated call should fail with 401 Unauthorized\n",
     "import requests\n",
     "\n",
-    "mcp_server_url = f\"{apim_resource_gateway_url}/mcp\"\n",
+    "mcp_server_url = mcp_api_endpoint  # e.g. https://<apim-gateway-host>/<mcpApiPath>/mcp\n",
     "utils.print_info(\"Calling sse endpoint WITHOUT authorization...\")\n",
     "utils.print_message(f\"MCP Server Url : {mcp_server_url}\")\n",
     "response = requests.post(mcp_server_url, headers={\"Content-Type\": \"application/json\"})\n",
@@ -299,13 +300,14 @@
     "1. Execute `npx @modelcontextprotocol/inspector` in a terminal\n",
     "2. Access the provided URL in a browser (it should open automatically).\n",
     "3. Set the transport type as `Streamable HTTP`\n",
-    "4. Provide the MCP server URL\n",
+    "4. Provide the MCP server URL (the `mcp_api_endpoint` value, e.g. `https://<apim-gateway-host>/<mcpApiPath>/mcp`)\n",
     "5. Click in the `Open Auth Settings` button\n",
-    "6. Click on `Quick OAuth Flow`\n",
-    "7. You’ll see a sign-in screen or an “Application Access Request” screen asking for your consent to use your signed-in account. After reviewing the request, click \"Allow\" to proceed.\n",
-    "8. After being redirected back to the MCP Inspector, scroll down to the `Authentication Complete` step. Expand the `Access Tokens` section and copy the `access_token` value.\n",
-    "9. Expand the Authentication section on the left and paste the `access_token` into the Bearer Token parameter.\n",
-    "10. Click on \"Connect\" and verify that the Weather Tool is functioning properly."
+    "6. In the auth settings, set the `Client ID` to your MCP app registration's `client_id` and set the `Scope` to `<mcp_api_endpoint>/user_impersonate` (e.g. `https://<apim-gateway-host>/<mcpApiPath>/mcp/user_impersonate` — the same value advertised in the `scopes_supported` field of the Protected Resource Metadata)\n",
+    "7. Click on `Quick OAuth Flow`\n",
+    "8. You’ll see a sign-in screen or an “Application Access Request” screen asking for your consent to use your signed-in account. After reviewing the request, click \"Allow\" to proceed.\n",
+    "9. After being redirected back to the MCP Inspector, scroll down to the `Authentication Complete` step. Expand the `Access Tokens` section and copy the `access_token` value.\n",
+    "10. Expand the Authentication section on the left and paste the `access_token` into the Bearer Token parameter.\n",
+    "11. Click on \"Connect\" and verify that the Weather Tool is functioning properly.\n"
    ]
   },
   {
@@ -322,7 +324,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pip2uv",
+   "display_name": "ai-gateway (3.12.13.final.0)",
    "language": "python",
    "name": "python3"
   },

--- a/labs/mcp-prm-oauth/mcp-prm-oauth.ipynb
+++ b/labs/mcp-prm-oauth/mcp-prm-oauth.ipynb
@@ -56,7 +56,7 @@
     "import utils\n",
     "\n",
     "deployment_name = os.path.basename(os.path.dirname(globals()['__vsc_ipynb_file__']))\n",
-    "resource_group_name = f\"lab-{deployment_name}-4\" # change the name to match your naming style\n",
+    "resource_group_name = f\"lab-{deployment_name}\" # change the name to match your naming style\n",
     "resource_group_location = \"ukwest\"\n",
     "resource_suffix = ''.join(random.choices(string.ascii_letters + string.digits, k=8)).lower()\n",
     "\n",

--- a/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-api.bicep
+++ b/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-api.bicep
@@ -14,11 +14,11 @@ param mcpAppTenantId string
 param mcpApiPath string = 'mcp'
 
 // Get reference to the existing APIM service
-resource apimService 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
+resource apimService 'Microsoft.ApiManagement/service@2025-09-01-preview' existing = {
   name: apimServiceName
 }
 
-resource dynamicDiscovery 'Microsoft.ApiManagement/service/apis@2023-05-01-preview' existing = {
+resource dynamicDiscovery 'Microsoft.ApiManagement/service/apis@2025-09-01-preview' existing = {
   parent: apimService
   name: 'mcp-prm-dynamic-discovery'
 }
@@ -71,36 +71,38 @@ resource mcpApiPathNamedValue 'Microsoft.ApiManagement/service/namedValues@2021-
   }
 }
 
-// Create mcp backend pointing to the Container App
-resource mcpBackend 'Microsoft.ApiManagement/service/backends@2024-06-01-preview' ={
+resource mcpBackendServerUrl 'Microsoft.ApiManagement/service/backends@2025-09-01-preview' = {
   parent: apimService
   name: '${webAppName}-mcp-backend'
   properties: {
+    url: 'https://${containerApp.properties.configuration.ingress.fqdn}'
     protocol: 'http'
-    url: 'https://${containerApp.properties.configuration.ingress.fqdn}/mcp'
     tls: {
       validateCertificateChain: true
       validateCertificateName: true
     }
     type: 'Single'
-  }  
+  }
 }
 
-// Create the MCP API definition in APIM
-resource mcpApi 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
+// Create the MCP Passthrough definition in APIM
+resource mcpApi 'Microsoft.ApiManagement/service/apis@2025-09-01-preview' = {
   parent: apimService
-  name: '${webAppName}-mcp-tools'
+  name: '${webAppName}-mcp-server'
   properties: {
-    displayName: '${webAppName} MCP Tools'
+    displayName: '${webAppName} MCP Server'
     type: 'mcp'
     subscriptionRequired: false
-    backendId: mcpBackend.name
-    path: '/${mcpApiPath}'
-    protocols: [
-      'https'
-    ]
-    mcpProperties:{
-      transportType: 'streamable'
+    backendId: mcpBackendServerUrl.name
+    description: 'MCP API for ${webAppName} retrieving authenticated account Graph info'
+    path: mcpApiPath    
+    protocols: ['https']
+    mcpProperties: {
+      endpoints : {
+        mcp: {
+          uriTemplate: '/mcp'
+        }
+      }
     }
     authenticationSettings: {
       oAuth2AuthenticationSettings: []
@@ -111,7 +113,7 @@ resource mcpApi 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
 }
 
 // Apply policy at the API level for all operations
-resource mcpApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-01-preview' = {
+resource mcpApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2025-09-01-preview' = {
   parent: mcpApi
   name: 'policy'
   properties: {
@@ -125,47 +127,20 @@ resource mcpApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-01-
   ]
 }
 
-// Create the PRM (Protected Resource Metadata) endpoint within MCP server
-resource mcpPrmOperation 'Microsoft.ApiManagement/service/apis/operations@2023-05-01-preview' = {
-  parent: mcpApi
-  name: 'mcp-prm-operation'
-  properties: {
-    displayName: 'Protected Resource Metadata'
-    method: 'GET'
-    urlTemplate: '/.well-known/oauth-protected-resource'
-    description: 'Protected Resource Metadata endpoint (RFC 9728)'
-  }
-}
-
-// Apply specific policy for the PRM endpoint (anonymous access)
-resource mcpPrmOperationPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2023-05-01-preview' = {
-  parent: mcpPrmOperation
-  name: 'policy'
-  properties: {
-    format: 'rawxml'
-    value: loadTextContent('mcp-prm.policy.xml')
-  }
-  dependsOn: [
-    APIMGatewayURLNamedValue
-    mcpTenantIdNamedValue
-    mcpClientIdNamedValue
-  ]
-}
-
 // Create the PRM (Protected Resource Metadata in the global discovery) endpoint - RFC 9728
-resource mcpPrmDiscoveryOperation 'Microsoft.ApiManagement/service/apis/operations@2023-05-01-preview' = {
+resource mcpPrmDiscoveryOperation 'Microsoft.ApiManagement/service/apis/operations@2025-09-01-preview' = {
   parent: dynamicDiscovery
   name: 'mcp-prm-discovery-operation'
   properties: {
     displayName: 'Protected Resource Metadata'
     method: 'GET'
-    urlTemplate: '/${mcpApiPath}'
+    urlTemplate: '/${mcpApiPath}/mcp'
     description: 'Protected Resource Metadata endpoint (RFC 9728)'
   }
 }
 
 // Apply specific policy for the PRM endpoint (anonymous access)
-resource mcpPrmGlobalPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2023-05-01-preview' = {
+resource mcpPrmGlobalPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2025-09-01-preview' = {
   parent: mcpPrmDiscoveryOperation
   name: 'policy'
   properties: {

--- a/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-api.policy.xml
+++ b/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-api.policy.xml
@@ -9,7 +9,9 @@
         <!-- Validate Azure AD JWT Token -->
         <validate-azure-ad-token tenant-id="{{McpTenantId}}" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized">
             <audiences>
+                <!-- v2 tokens carry the appId (GUID) as aud; the Application ID URI is accepted too. -->
                 <audience>{{McpClientId}}</audience>
+                <audience>{{APIMGatewayURL}}/{{McpApiPath}}</audience>
             </audiences>
         </validate-azure-ad-token>
     </inbound>

--- a/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-api.policy.xml
+++ b/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-api.policy.xml
@@ -6,14 +6,14 @@
 <policies>
     <inbound>
         <base />
-        <!-- Validate Azure AD JWT Token -->
-        <validate-azure-ad-token tenant-id="{{McpTenantId}}" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized">
-            <audiences>
-                <!-- v2 tokens carry the appId (GUID) as aud; the Application ID URI is accepted too. -->
-                <audience>{{McpClientId}}</audience>
-                <audience>{{APIMGatewayURL}}/{{McpApiPath}}</audience>
-            </audiences>
-        </validate-azure-ad-token>
+            <!-- Validate Azure AD JWT Token -->
+
+            <validate-azure-ad-token tenant-id="{{McpTenantId}}" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized">
+                <audiences>
+                    <audience>{{McpClientId}}</audience>
+                    <audience>{{APIMGatewayURL}}/{{McpApiPath}}</audience>
+                </audiences>
+            </validate-azure-ad-token>
     </inbound>
     <backend>
         <base />
@@ -28,11 +28,10 @@
                 <return-response>
                     <set-status code="401" reason="Unauthorized" />
                     <set-header name="WWW-Authenticate" exists-action="override">
-                        <value>Bearer error="invalid_token", resource_metadata="{{APIMGatewayURL}}/.well-known/oauth-protected-resource"</value>
+                        <value>Bearer error="invalid_token", resource_metadata="{{APIMGatewayURL}}/.well-known/oauth-protected-resource/{{McpApiPath}}/mcp/"</value>
                     </set-header>
                 </return-response>
             </when>
         </choose>
-        <!-- Handle authentication/authorization errors -->
     </on-error>
 </policies>

--- a/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-prm.policy.xml
+++ b/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-prm.policy.xml
@@ -17,7 +17,7 @@
             </set-header>
             <set-body>@{
                 return JsonConvert.SerializeObject(new {
-                    resource = "{{APIMGatewayURL}}/{{McpApiPath}}",
+                    resource = "{{APIMGatewayURL}}/{{McpApiPath}}/mcp",
                     authorization_servers = new[] {
                         $"https://login.microsoftonline.com/{{McpTenantId}}/v2.0"
                     },
@@ -25,7 +25,7 @@
                         "header"
                     },
                     scopes_supported = new[] {
-                        "{{APIMGatewayURL}}/{{McpApiPath}}/user_impersonate"
+                        "{{APIMGatewayURL}}/{{McpApiPath}}/mcp/user_impersonate"
                     }
                 });
             }</set-body>

--- a/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-prm.policy.xml
+++ b/labs/mcp-prm-oauth/src/bicep/apim-mcp/mcp-prm.policy.xml
@@ -25,7 +25,7 @@
                         "header"
                     },
                     scopes_supported = new[] {
-                        "{{McpClientId}}/user_impersonate"
+                        "{{APIMGatewayURL}}/{{McpApiPath}}/user_impersonate"
                     }
                 });
             }</set-body>

--- a/labs/mcp-prm-oauth/src/bicep/identity/mcp-entra-app.bicep
+++ b/labs/mcp-prm-oauth/src/bicep/identity/mcp-entra-app.bicep
@@ -15,6 +15,9 @@ param userAssignedIdentityPrincipleId string
 @description('The container app name for callback URL configuration')
 param webAppName string
 
+@description('The Application ID URI to expose (must match the PRM resource and the JWT audience). Example: https://<apim>.azure-api.net/mcp')
+param applicationIdUri string
+
 var loginEndpoint = environment().authentication.loginEndpoint
 var issuer = '${loginEndpoint}${tenantId}/v2.0'
 
@@ -26,6 +29,10 @@ resource containerApp 'Microsoft.App/containerApps@2023-11-02-preview' existing 
 resource mcpEntraApp 'Microsoft.Graph/applications@v1.0' = {
   displayName: mcpAppDisplayName
   uniqueName: mcpAppUniqueName
+  // Application ID URI. Aligns with the PRM 'resource' and the validate-jwt audience.
+  identifierUris: [
+    applicationIdUri
+  ]
   api: {
     oauth2PermissionScopes: [
       {
@@ -63,6 +70,14 @@ resource mcpEntraApp 'Microsoft.Graph/applications@v1.0' = {
   spa: {
     redirectUris: [
       'https://${containerApp.properties.configuration.ingress.fqdn}/auth/callback'
+    ]
+  }
+  // Public client (Authorization Code + PKCE, no client secret) for MCP Inspector.
+  // Registering these as public-client (not SPA) redirect URIs avoids AADSTS9002327.
+  publicClient: {
+    redirectUris: [
+      'http://localhost:6274/oauth/callback'
+      'http://localhost:6274/oauth/callback/debug'
     ]
   }
 

--- a/labs/mcp-prm-oauth/src/bicep/identity/mcp-entra-app.bicep
+++ b/labs/mcp-prm-oauth/src/bicep/identity/mcp-entra-app.bicep
@@ -9,17 +9,16 @@ param mcpAppDisplayName string
 @description('Tenant ID where the application is registered')
 param tenantId string = tenant().tenantId
 
-@description('The principle id of the user-assigned managed identity')
-param userAssignedIdentityPrincipleId string
-
 @description('The container app name for callback URL configuration')
 param webAppName string
 
-@description('The Application ID URI to expose (must match the PRM resource and the JWT audience). Example: https://<apim>.azure-api.net/mcp')
+@description('The principle id of the user-assigned managed identity')
+param userAssignedIdentityPrincipleId string
+
+@description('The Application ID URI (identifier URI) to expose, e.g. https://<apim>.azure-api.net/<mcpname>/mcp')
 param applicationIdUri string
 
-var loginEndpoint = environment().authentication.loginEndpoint
-var issuer = '${loginEndpoint}${tenantId}/v2.0'
+var issuer = '${environment().authentication.loginEndpoint}${tenantId}/v2.0'
 
 // Get reference to the Container App
 resource containerApp 'Microsoft.App/containerApps@2023-11-02-preview' existing = {
@@ -29,7 +28,6 @@ resource containerApp 'Microsoft.App/containerApps@2023-11-02-preview' existing 
 resource mcpEntraApp 'Microsoft.Graph/applications@v1.0' = {
   displayName: mcpAppDisplayName
   uniqueName: mcpAppUniqueName
-  // Application ID URI. Aligns with the PRM 'resource' and the validate-jwt audience.
   identifierUris: [
     applicationIdUri
   ]
@@ -49,7 +47,7 @@ resource mcpEntraApp 'Microsoft.Graph/applications@v1.0' = {
     requestedAccessTokenVersion: 2
     preAuthorizedApplications: [
       {
-        appId: 'aebc6443-996d-45c2-90f0-388ff96faa56'
+        appId: 'aebc6443-996d-45c2-90f0-388ff96faa56' // Visual studio code well known client id for OAuth2.0 authorization code flow
         delegatedPermissionIds: [
           guid(mcpAppUniqueName, 'user_impersonate')
         ]
@@ -85,14 +83,14 @@ resource mcpEntraApp 'Microsoft.Graph/applications@v1.0' = {
     name: '${mcpEntraApp.uniqueName}/msiAsFic'
     description: 'Trust the user-assigned MI as a credential for the MCP app'
     audiences: [
-       'api://AzureADTokenExchange'
+      'api://AzureADTokenExchange'
     ]
     issuer: issuer
     subject: userAssignedIdentityPrincipleId
   }
 }
 
-resource applicationRegistrationServicePrincipal 'Microsoft.Graph/servicePrincipals@v1.0' = {
+resource mcpServicePrincipal 'Microsoft.Graph/servicePrincipals@v1.0' = {
   appId: mcpEntraApp.appId
 }
 

--- a/modules/apim/v4/apim.bicep
+++ b/modules/apim/v4/apim.bicep
@@ -1,0 +1,175 @@
+/**
+ * @module apim-v1 (v.2025-09-01-preview)
+ * @description This module defines the Azure API Management (APIM) resources using Bicep.
+ * It includes configurations for creating and managing APIM instance.
+ * This is version 1 (v1) of the APIM Bicep module.
+ */
+
+// ------------------
+//    PARAMETERS
+// ------------------
+
+@description('The suffix to append to the API Management instance name. Defaults to a unique string based on subscription and resource group IDs.')
+param resourceSuffix string = uniqueString(subscription().id, resourceGroup().id)
+
+@description('The name of the API Management instance. Defaults to "apim-<resourceSuffix>".')
+param apiManagementName string = 'apim-${resourceSuffix}'
+
+@description('The location of the API Management instance. Defaults to the resource group location.')
+param location string = resourceGroup().location
+
+@description('The email address of the publisher. Defaults to "noreply@microsoft.com".')
+param publisherEmail string = 'noreply@microsoft.com'
+
+@description('The name of the publisher. Defaults to "Microsoft".')
+param publisherName string = 'Microsoft'
+
+@description('The pricing tier of this API Management service')
+@allowed([
+  'Consumption'
+  'Developer'
+  'Basic'
+  'Basicv2'
+  'Standard'
+  'Standardv2'
+  'Premium'
+])
+param apimSku string = 'Basicv2'
+
+@description('The type of managed identity to by used with API Management')
+@allowed([
+  'SystemAssigned'
+  'UserAssigned'
+  'SystemAssigned, UserAssigned'
+])
+param apimManagedIdentityType string = 'SystemAssigned'
+
+@description('The user-assigned managed identity ID to be used with API Management')
+param apimUserAssignedManagedIdentityId string = ''
+
+@description('Configuration array for APIM subscriptions')
+param apimSubscriptionsConfig array = []
+
+@description('The Log Analytics Workspace ID for diagnostic settings')
+param lawId string = ''
+
+@description('The instrumentation key for Application Insights')
+param appInsightsInstrumentationKey string = ''
+
+@description('The resource ID for Application Insights')
+param appInsightsId string = ''
+
+@description('The release channel for the API Management service')
+@allowed([
+  'Early'
+  'Default'
+  'Late'
+  'GenAI'
+])
+param releaseChannel string = 'Default'
+
+// ------------------
+//    VARIABLES
+// ------------------
+
+
+// ------------------
+//    RESOURCES
+// ------------------
+
+// https://learn.microsoft.com/azure/templates/microsoft.apimanagement/service
+resource apimService 'Microsoft.ApiManagement/service@2025-09-01-preview' = {
+  name: apiManagementName
+  location: location
+  sku: {
+    name: apimSku
+    capacity: 1
+  }
+  properties: {
+    publisherEmail: publisherEmail
+    publisherName: publisherName
+    releaseChannel: releaseChannel
+  }
+  identity: {
+    type: apimManagedIdentityType
+    userAssignedIdentities: apimManagedIdentityType == 'UserAssigned' && apimUserAssignedManagedIdentityId != '' ? {
+      // BCP037: Not yet added to latest API:
+      '${apimUserAssignedManagedIdentityId}': {}
+    } : null
+  }
+}
+
+resource apimDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if(length(lawId) > 0) {
+  scope: apimService
+  name: 'apimDiagnosticSettings'
+  properties: {
+    workspaceId: lawId
+    logAnalyticsDestinationType: 'Dedicated'
+    logs: [
+      {
+        categoryGroup: 'AllLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
+resource apimLogger 'Microsoft.ApiManagement/service/loggers@2025-09-01-preview' = if(length(lawId) > 0) {
+  parent: apimService
+  name: 'azuremonitor'
+  properties: {
+    loggerType: 'azureMonitor'
+    isBuffered: false // Set to false to ensure logs are sent immediately
+  }
+}
+
+// Create a logger only if we have an App Insights ID and instrumentation key.
+resource apimAppInsightsLogger 'Microsoft.ApiManagement/service/loggers@2025-09-01-preview' = if (!empty(appInsightsId) && !empty(appInsightsInstrumentationKey)) {
+  name: 'appinsights-logger'
+  parent: apimService
+  properties: {
+    credentials: {
+      instrumentationKey: appInsightsInstrumentationKey
+    }
+    description: 'APIM Logger for Application Insights'
+    isBuffered: false
+    loggerType: 'applicationInsights'
+    resourceId: appInsightsId
+  }
+}
+
+@batchSize(1)
+resource apimSubscription 'Microsoft.ApiManagement/service/subscriptions@2025-09-01-preview' = [for subscription in apimSubscriptionsConfig: if(length(apimSubscriptionsConfig) > 0) {
+  name: subscription.name
+  parent: apimService
+  properties: {
+    allowTracing: true
+    displayName: '${subscription.displayName}'
+    scope: '/apis'
+    state: 'active'
+  }
+}]
+
+
+// ------------------
+//    OUTPUTS
+// ------------------
+
+output id string = apimService.id
+output name string = apimService.name
+output principalId string = (apimManagedIdentityType == 'SystemAssigned') ? apimService.identity.principalId : ''
+output gatewayUrl string = apimService.properties.gatewayUrl
+output loggerId string = (length(lawId) > 0) ? apimLogger.id : ''
+
+#disable-next-line outputs-should-not-contain-secrets
+output apimSubscriptions array = [for (subscription, i) in apimSubscriptionsConfig: {
+  name: subscription.name
+  displayName: subscription.displayName
+  key: apimSubscription[i].listSecrets().primaryKey
+}]


### PR DESCRIPTION
# PR: Fix MCP Inspector authorization flow to reflect PRM resource id

## Concrete repro step before fix : 

<img width="1689" height="1031" alt="image" src="https://github.com/user-attachments/assets/24f8578a-c0fa-40a0-9606-7f33db0fbbf4" />

## Purpose

* Aligns the `mcp-prm-oauth` lab with **RFC 9728 (Protected Resource Metadata)** by using the **full APIM MCP endpoint URL** (`{APIMGatewayURL}/{mcpApiPath}/mcp`) as the OAuth *resource identifier*, instead of the Entra application `client_id`.
* Fixes the MCP Inspector / VS Code authorization flow so the advertised `resource`, `scopes_supported`, JWT `audience`, `WWW-Authenticate` metadata URL, and the Entra app **Application ID URI** all reference the same PRM resource id and are consistent end-to-end.
* Updates the Entra ID app registration so it exposes the correct `identifierUris` (Application ID URI) and is configured as a public client (Authorization Code + PKCE) with a federated credential trusting the user-assigned managed identity.
* Introduces a new **`modules/apim/v4/apim.bicep`** module targeting the `2025-09-01-preview` API Management API version and migrates the lab to it.
* Improves lab clean-up to also remove the Entra ID app registration (which lives in Entra ID, not in the resource group) and makes resource/app naming deterministic.

## Does this introduce a breaking change?

```text
[ ] Yes
[x] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```text
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Get the code

```bash
git clone https://github.com/Azure-Samples/AI-Gateway.git
cd AI-Gateway
git checkout fix/mcp-prm-inspector-authentication
```

* Test the code

```text
1. Open labs/mcp-prm-oauth/mcp-prm-oauth.ipynb and run all cells to deploy the
   infrastructure (APIM v4 module, Container App MCP server, Entra app registration).

2. Run the "Test the authorization WITHOUT a valid token" cell and confirm a
   401 Unauthorized is returned, with a WWW-Authenticate header pointing at
   {APIMGatewayURL}/.well-known/oauth-protected-resource/{mcpApiPath}/mcp/.

3. Test with the MCP Inspector:
   - Run `npx @modelcontextprotocol/inspector`.
   - Transport: Streamable HTTP; URL: the mcp_api_endpoint value.
   - In Auth Settings, set the Scope to
     <mcp_api_endpoint>/user_impersonate (the value advertised in
     scopes_supported of the Protected Resource Metadata).
   - Run Quick OAuth Flow, consent, and confirm the tool call succeeds.

4. (Optional) Repeat the flow with VS Code GitHub Copilot (MCP: Add Server).

5. Run clean-up-resources.ipynb and confirm both the Azure resources and the
   Entra app registration are removed.
```

## What to Check

Verify that the following are valid:

* The Protected Resource Metadata (`mcp-prm.policy.xml`) advertises `resource = {APIMGatewayURL}/{mcpApiPath}/mcp` and `scopes_supported = {APIMGatewayURL}/{mcpApiPath}/mcp/user_impersonate`.
* The `validate-azure-ad-token` policy (`mcp-api.policy.xml`) accepts both the MCP `client_id` and the `{APIMGatewayURL}/{mcpApiPath}` audience.
* The 401 `WWW-Authenticate` header returns `resource_metadata` pointing to `.well-known/oauth-protected-resource/{mcpApiPath}/mcp/`.
* The Entra app registration (`mcp-entra-app.bicep`) is created with the correct `identifierUris` (Application ID URI), public-client configuration, and federated credential.
* The lab deploys against the new `modules/apim/v4/apim.bicep` module and the `2025-09-01-preview` resource API versions.
* MCP Inspector and VS Code complete the OAuth flow and successfully invoke the tool.
* Clean-up removes the app registration in addition to the resource group resources.